### PR TITLE
Proposed addition of pages for HPC on prem/cloud

### DIFF
--- a/_computing/cluster_cloudCompute.md
+++ b/_computing/cluster_cloudCompute.md
@@ -1,0 +1,11 @@
+---
+title: Cloud Computing at Fred Hutch
+last_modified_at: 2018-08-02
+---
+These are cloud based high performance computing resources.  
+
+
+## Beagle
+
+
+## Globus Genomics

--- a/_computing/cluster_cloudCompute.md
+++ b/_computing/cluster_cloudCompute.md
@@ -2,10 +2,7 @@
 title: Cloud Computing at Fred Hutch
 last_modified_at: 2018-08-02
 ---
-These are cloud based high performance computing resources.  
-
-
-## Beagle
+These are cloud based high performance computing resources.  More to come here as more resources are supported by the Fred Hutch. 
 
 
 ## Globus Genomics

--- a/_computing/cluster_overview.md
+++ b/_computing/cluster_overview.md
@@ -2,29 +2,8 @@
 title: High Performance Computing Overview
 last_modified_at: 2018-06-20
 ---
-This section contains articles that describe a range of computing resource options available to Fred Hutch researchers, all the way from a single laptop to the Fred Hutch on-premise high performance computing cluster (`gizmo`) to various cloud-based options, as well as how to get started using each platform.
+This section contains articles that describe a range of high performance computing resource options available to Fred Hutch researchers.
 
-## Interactive Computing: Command Line Interface (CLI), Moderate to High Capability
-These systems are provided by the Fred Hutch to serve needs that rise above those that can be met using the above listed platforms.  Often reasons to move to these HPC resources include the need for version controlled, specialized package/module/tool configurations, higher compute resource needs, or rapid access to large data sets in data storage locations not accessible with the required security for the data type by the above systems. In the table below, `gizmo` is actually the compute resource that can be accessed via multiple tools, which are also listed below.  
+## On-Premise HPC
 
-Compute Resource | Access Interface | Resource Admin | Connection to FH Data Storage
---- | --- | --- | ---
-Gizmo | Via Rhino or NoMachine hosts (CLI, FH credentials on campus/VPN off campus) | Scientific Computing | Direct to all local storage types
-  |   |   |  
-Rhino | CLI, FH credentials on campus/VPN off campus | Scientific Computing | Direct to all local storage types
-NoMachine | NX Client, FH credentials on campus/VPN off campus | Scientific Computing | Direct to all local storage types
-Python/Jupyter Notebooks | Via Rhino (CLI, FH credentials on campus/VPN off campus) | Scientific Computing | Direct to all local storage types
-R/R Studio | Via Rhino (CLI, FH credentials on campus/VPN off campus) | Scientific Computing | Direct to all local storage types
-
-### Meet `Rhino`
-`Gizmo` is actually not a stand alone system like the above section; instead, access to the resource is based on the Rhino platform supported by Center IT.  `Rhino`, or more specifically the Rhinos are the locally managed HPC resources that are actually three different servers all accessed via the name `rhino`. Together, they function as a data and compute hub for a variety of data storage resources and high performance computing (HPC).  The specific guidance for the use of each of the approaches to HPC access are slightly different, but will all require the user to learn how to access and interact with `Rhino`.  Any user interacting with the following systems will be dependent on being proficient with the care and keeping of the Rhinos.
-
-## Interactive Computing: Future Systems Currently Under Development
-These systems are provided by the Fred Hutch to serve needs that rise above those that can be met using the above listed platforms.
-
-Compute Resource | Access Interface | Resource Admin | Connection to FH Data Storage
---- | --- | --- | ---
-Beagle | Via Rhino or NoMachine hosts (CLI, FH credentials on campus/VPN off campus) | Center IT | _home_, _fast_, _economy_, AWS-S3, and Beagle-specific _scratch_
-
-
-<!-- Globus Genomics, Zeppelin-->
+## Cloud Computing

--- a/_computing/cluster_rhinoGizmo.md
+++ b/_computing/cluster_rhinoGizmo.md
@@ -1,0 +1,19 @@
+---
+title: On-Premise HPC at Fred Hutch
+last_modified_at: 2018-08-02
+---
+
+## Interactive Computing: Command Line Interface (CLI), Moderate to High Capability
+These systems are provided by the Fred Hutch to serve needs that rise above those that can be met using the above listed platforms.  Often reasons to move to these HPC resources include the need for version controlled, specialized package/module/tool configurations, higher compute resource needs, or rapid access to large data sets in data storage locations not accessible with the required security for the data type by the above systems. In the table below, `gizmo` is actually the compute resource that can be accessed via multiple tools, which are also listed below.  
+
+Compute Resource | Access Interface | Resource Admin | Connection to FH Data Storage
+--- | --- | --- | ---
+Gizmo | Via Rhino or NoMachine hosts (CLI, FH credentials on campus/VPN off campus) | Scientific Computing | Direct to all local storage types
+  |   |   |  
+Rhino | CLI, FH credentials on campus/VPN off campus | Scientific Computing | Direct to all local storage types
+NoMachine | NX Client, FH credentials on campus/VPN off campus | Scientific Computing | Direct to all local storage types
+Python/Jupyter Notebooks | Via Rhino (CLI, FH credentials on campus/VPN off campus) | Scientific Computing | Direct to all local storage types
+R/R Studio | Via Rhino (CLI, FH credentials on campus/VPN off campus) | Scientific Computing | Direct to all local storage types
+
+## Meet `Rhino`
+`Gizmo` is actually not a stand alone system, instead, access to the resource is based on the Rhino platform supported by Center IT.  `Rhino`, or more specifically the Rhinos are the locally managed HPC resources that are actually three different servers all accessed via the name `rhino`. Together, they function as a data and compute hub for a variety of data storage resources and high performance computing (HPC).  The specific guidance for the use of each of the approaches to HPC access are slightly different, but will all require the user to learn how to access and interact with `Rhino`.  Any user interacting with the following systems will be dependent on being proficient with the care and keeping of the Rhinos.

--- a/_computing/cluster_rhinoGizmo.md
+++ b/_computing/cluster_rhinoGizmo.md
@@ -14,6 +14,7 @@ Rhino | CLI, FH credentials on campus/VPN off campus | Scientific Computing | Di
 NoMachine | NX Client, FH credentials on campus/VPN off campus | Scientific Computing | Direct to all local storage types
 Python/Jupyter Notebooks | Via Rhino (CLI, FH credentials on campus/VPN off campus) | Scientific Computing | Direct to all local storage types
 R/R Studio | Via Rhino (CLI, FH credentials on campus/VPN off campus) | Scientific Computing | Direct to all local storage types
+Beagle | Via Rhino or NoMachine hosts (CLI, FH credentials on campus/VPN off campus) | Center IT | _home_, _fast_, _economy_, AWS-S3, and Beagle-specific _scratch_
 
 ## Meet `Rhino`
 `Gizmo` is actually not a stand alone system, instead, access to the resource is based on the Rhino platform supported by Center IT.  `Rhino`, or more specifically the Rhinos are the locally managed HPC resources that are actually three different servers all accessed via the name `rhino`. Together, they function as a data and compute hub for a variety of data storage resources and high performance computing (HPC).  The specific guidance for the use of each of the approaches to HPC access are slightly different, but will all require the user to learn how to access and interact with `Rhino`.  Any user interacting with the following systems will be dependent on being proficient with the care and keeping of the Rhinos.

--- a/_computing/comp_index.md
+++ b/_computing/comp_index.md
@@ -15,7 +15,9 @@ last_modified_at: 2018-07-19
 - Collaborative Storage Systems
 
 
-## [High Performance Computing]({{ site.baseurl }}/computing/hpc/)
+## [High Performance Computing]({{ site.baseurl }}/computing/cluster_overview/)
+- [On-Premise HPC (Rhino/Gizmo)]({{ site.baseurl }}/computing/cluster_rhinoGizmo/)
+- [Cloud Computing]({{ site.baseurl }}/computing/cluster_cloudCompute/)
 
 
 ## [Linux]({{ site.baseurl }}/computing/linux_overview/)

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -157,6 +157,10 @@ computing:
     children:
       - title: "Overview"
         url: /computing/cluster_overview/
+      - title: "Rhino/Gizmo"
+        url: /computing/cluster_rhinoGizmo/
+      - title: "Cloud Computing"
+        url: /computing/cluster_cloudCompute/
 
   - title: "Linux"
     children:


### PR DESCRIPTION
I added a page for cloud computing and for rhino/gizmo, b/c these two pages are ones that many researchers have needed.  Maybe one will be fairly small for now (cloud), but the rhino page could get filled ASAP.  