### PR TITLE
Typo/ minor edits, link to rstudio.fhcrc.org

### DIFF
--- a/_bioinformatics/compute_uis.md
+++ b/_bioinformatics/compute_uis.md
@@ -3,10 +3,10 @@ title: Notebooks and User Interfaces for R, Python and Other Computing Languages
 last_modified_at: 2018-08-29
 author_list: Dirk Petersen
 ---
-While programming in R, Python or other languages is an important skill to learn, another layer of how to actually implement and manage processes you have developed in the code you've written can be useful.  To manage the interface between code and environments, versioning and more integrated features (e.g. git or multi-langage processes), various Notebook or User Interfaces exist.  This document is an overview of common user interfaces commonly used to manage or interact with code.  
+While programming in R, Python or other languages is an important skill to learn, another layer of how to actually implement and manage processes you have developed in the code you've written can be useful.  To manage the interface between code and environments, versioning and more integrated features (e.g. git or multi-langage processes), various Notebook or User Interfaces exist.  This document is an overview of common user interfaces used to manage or interact with code.  
 
 ## RStudio IDE
-The RStudio IDE is a free and open source, commonly used interface to R, which supports a number of added features including a GUI that can be customized to view aspects of your work of most importance (such as plots, files, environment variables, scripts, workspaces, etc).  RStudio is free and can be [downloaded here](https://www.rstudio.com/), and requires an installation of R itself, which can be [downloaded here, or obtained via Center IT's Self Service tools.](https://cran.r-project.org/)
+The RStudio IDE is a free and open source, popular interface to R, which supports a number of added features including a GUI that can be customized to view aspects of your work of most importance (such as plots, files, environment variables, scripts, workspaces, etc).  RStudio is free and can be [downloaded here](https://www.rstudio.com/), and requires an installation of R itself, which can be [downloaded here, or obtained via Center IT's Self Service tools.](https://cran.r-project.org/)  Alternatively, a Hutch supported RStudio server can be accessed at [rstudio.fhcrc.org](http://rstudio.fhcrc.org). <!-- Note, this is currently using http, not https, so not secure in its transfer of user passwords!  But, scicomp documenation (https://teams.fhcrc.org/sites/citwiki/SciComp/Pages/Rstudio%20Server,%20rstudio.fhcrc.org.aspx) states this is only accessible from within the Hutch, so is maybe ok?? -->
 
 RStudio has a few particularly useful features, that include:
 - Support for R Markdowns/Notebooks
@@ -19,7 +19,7 @@ RStudio is typically run locally on desktop computers, but as compute resources 
 
 ## Jupyter Notebooks
 
-Jupyter Notebooks are web interfaces to an interpreter shell such as Python. They are most used by data scientist who would like to experiment with their code and easily generate charts and graphs. At Fred Hutch there are at least 4 ways how you can use Jupyter Notebooks, includign the latest incarnation called 'Jupyter Lab'.  You can find more information about Jupyter and related technologies [here at the Project Jupyter site.](http://jupyter.org/)
+Jupyter Notebooks are web interfaces to an interpreter shell such as Python. They are most used by data scientist who would like to experiment with their code and easily generate charts and graphs. At Fred Hutch there are at least 4 ways how you can use Jupyter Notebooks, including the latest incarnation called 'Jupyter Lab'.  You can find more information about Jupyter and related technologies [here at the Project Jupyter site.](http://jupyter.org/)
 
 ### Jupyter Notebook on your Computer
 
@@ -44,7 +44,7 @@ Just load a Python distribution maintained by SciComp and run Jupyter lab, use t
     petersen@rhino1:~$ jupyter lab --ip=0.0.0.0 --port=$(fhfreeport) --no-browser
 ```
 
-Then you connect to the URL:
+Then you connect to the URL, copying the link given by the previous command, which looks as follows:
 ```
        Copy/paste this URL into your browser when you connect for the first time,
     to login with a token:
@@ -62,7 +62,7 @@ SciComp maintains an installation of [Jupyterhub](https://jupyterhub.fhcrc.org/)
 - Pro: Leave your notebook runnning for long time, web only solution and no Linux login via ssh required
 - Con: outdated Python and cannot use Chrome Browser 
 
-Also only the first method allows you to install your own python packages as root user. The other 3 methods require you to either request a package from Scientic Computing or to create a virtual Python environment, for example:
+Also only the first method allows you to install your own python packages as root user. The other 3 methods require you to either request a package from Scientific Computing or to create a virtual Python environment, for example:
 ```
     petersen@rhino1:~$ ml Python/3.6.5-foss-2016b-fh3
     petersen@rhino1:~$ python3 -m venv ~/mypython


### PR DESCRIPTION
Also, added a comment in the .md file to note: rstudio.fhcrc.org is currently accessible only via an unencrypted connection, potentially exposing user passwords.  But, as the [scicomp documentation states](https://teams.fhcrc.org/sites/citwiki/SciComp/Pages/Rstudio%20Server,%20rstudio.fhcrc.org.aspx), rstudio.fhcrc.org is only accessible within the Hutch, so maybe we are ok with this?