### PR TITLE
change to workspace setting of vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "pasteImage.path": "${projectRoot}/assets/${currentFileNameWithoutExt}/",
+    "pasteImage.basePath": "${projectRoot}/assets",
+    "pasteImage.forceUnixStyleSeparator": true,
+    "pasteImage.prefix": "/assets/"
+}

--- a/_compdemos/vscode_markdown_howto.md
+++ b/_compdemos/vscode_markdown_howto.md
@@ -65,7 +65,7 @@ By default, Paste Image will create (if it doesn't already exist) a single "imag
     "pasteImage.prefix": "/assets/"
 }
 ```
-In this example the sub-folder that will be created in the assets folder named after your file name (this just lets us avoid a single huge assets folder in the long run).  **Note:** if you are editing markdown that is destined for the [Fred Hutch Wiki,](/) you must use the above configuration. However in other contexts, you may need to use another folder name like `images` in order for certain processes to function.
+In this example the sub-folder that will be created in the assets folder named after your file name (this just lets us avoid a single huge assets folder in the long run).  **Note:** if you are editing markdown that is destined for the [Fred Hutch Wiki,](/) you must use the above configuration. It is set in the workspace settings for vscode at /.vscode/settings.json which will override the user settings. However in other contexts, you may need to use another folder name like `images` in order for certain processes to function.
 
 After the `Paste Image` plugin is installed and configured, you can simply copy your prepared image or screenshot, insert the cursor where you want to insert the image in the document and use **Ctr+Alt+V** on Windows or Linux and **Command+Alt+V** on macOS. This will automatically create the assets (or whatever you've named it) folder if doesn't already exist and place your image there naming it with a date/timestamp. The inserted text in the editor will look like the following:
 


### PR DESCRIPTION
override user settings with work space settings for vs code

    "pasteImage.path": "${projectRoot}/assets/${currentFileNameWithoutExt}/",
    "pasteImage.basePath": "${projectRoot}/assets",
    "pasteImage.forceUnixStyleSeparator": true,
    "pasteImage.prefix": "/assets/"

this allows us to only temporarily change the settings while writing the wiki. it  also enforces the correct settings