### PR TITLE
jupyter lab start instructions

### DIFF
--- a/_bioinformatics/compute_uis.md
+++ b/_bioinformatics/compute_uis.md
@@ -43,7 +43,7 @@ Just load a Python distribution maintained by SciComp and run Jupyter lab. Use t
 
 ```
     petersen@rhino1:~$ ml Python/3.6.5-foss-2016b-fh3
-    petersen@rhino1:~$ jupyter lab --ip=0.0.0.0 --port=$(fhfreeport) --no-browser
+    petersen@rhino1:~$ jupyter lab --no-browser
 ```
 
 Then you connect to the URL, copying the link given by the previous command, which looks as follows:


### PR DESCRIPTION
Simplify the start instructions for jupyter notebooks on rhino's.
the option --no-browser will pick an unused port above 8888 automatically. 
