### PR TITLE
remove costs

### DIFF
--- a/_computing/store_objectstore.md
+++ b/_computing/store_objectstore.md
@@ -1,6 +1,6 @@
 ---
 title: Data Storage in Object Storage Systems (*Economy*)
-last_modified_at: 2018-11-26
+last_modified_at: 2019-02-07
 primary_reviewers: dirkpetersen, dtenenba
 ---
 Object storage systems are not directly attached to your computer via drive mapping, a mount point or the Mac Finder, so you cannot just (double)click on a file to edit it with your favorite application. Most software used in life sciences cannot work directly with an object storage system as if the files were stored in traditional file storage systems. So why would you even want to use it if it seems more complicated than file storage? Object storage systems scale better in capacity and performance and are much cheaper to operate than traditional file storage systems. Cloud Computing depends very much on object storage systems such as Amazon's AWS S3 or Google Cloud Storage.
@@ -62,5 +62,3 @@ Once you have [obtained S3 credentials](/computing/access_credentials/), you can
 #### User Demos
 We have a number of demos in our Resource Library related to how to interact with Economy Storage, specifically via [a desktop client](/compdemos/Mountain-CyberDuck/), [via the AWS CLI](/compdemos/aws-cli/), [via R](/compdemos/aws-R/), or [via Python](/compdemos/aws-python/).
 
-
->NOTE: This article is a work in progress. If you have suggestions or would like to contribute email `sciwiki`.  

--- a/_computing/store_posix.md
+++ b/_computing/store_posix.md
@@ -1,6 +1,6 @@
 ---
 title: Data Storage in File (Block) Storage Systems
-last_modified_at: 2018-11-26
+last_modified_at: 2019-02-07
 primary_reviewer: dirkpetersen
 ---
 
@@ -27,7 +27,7 @@ The data here is organized by investigator- each folder at the top level is name
 
 On SciComp supported Linux systems you will see this storage in the path `/fh/fast`.  Windows systems can access this via the UNC path `\\center.fhcrc.org\fh\fast` and OSX hosts using the path `smb://center.fhcrc.org/fh/fast`.  
 
-This storage platform is appropriate for most scientific data- particularly large data sets.  There is no charge for the first 5TB of storage on this system: there is a $30 per-month charge for every terabyte above this.
+This storage platform is appropriate for most scientific data- particularly large data sets.  
 
 ## *Secure*
 
@@ -35,4 +35,4 @@ This storage platform is appropriate for most scientific data- particularly larg
 
 Secure file is available via the path `/fh/fast/secure/research/lastname_f` on SciComp Linux systems, `\\center.fhcrc.org\fh\secure\research\lastname_f` on Windows hosts, and `smb://center/fh/secure/research/lastname_f` on OSX.
 
-This storage platform can be used for storing PHI.  It must be noted, however, that many connected systems may not be appropriate for analysis of PHI data.  The first terabyte of data is provided by CIT with a charge of $50 per-terabyte for any amount above that.
+This storage platform can be used for storing PHI.  It must be noted, however, that many connected systems may not be appropriate for analysis of PHI data. 


### PR DESCRIPTION
remove explicit references to storage costs from storage pages. Perhaps @dirkpetersen can link to a centernet page containing the current, maintained costs list so we can only manage that in one place?