### PR TITLE
Add outline for J node specs in nodes database

### DIFF
--- a/_data/cluster_nodes.yaml
+++ b/_data/cluster_nodes.yaml
@@ -69,11 +69,11 @@
       processor_manufacturer: Intel
       manufacturer: SuperMicro
       vendor: Silicon Mechanics
-      model: xxxxU 2U Ultra NVMe Server
+      model: 6029U 2U Ultra NVMe Server
       os: Ubuntu 14.04 LTS
-      local_storage: "7TB @ /loc (?MB/s throughput / ? IOps)"
+      local_storage: "7TB @ /loc (300MB/s throughput / 1000 IOps)"
       network: 10G (up to 1GB/s throughput)
-      gpu: NVIDIA
+      gpu: NVIDIA GeForce GTX 1080Ti
       node_count: 42
       partition: largenode
     -  

--- a/_data/cluster_nodes.yaml
+++ b/_data/cluster_nodes.yaml
@@ -61,6 +61,22 @@
       node_count: 3
       partition: largenode
     -  
+      node_name: j
+      cores: 24
+      sockets: 2
+      memory_gb: 384
+      processor_model: Gold 6146
+      processor_manufacturer: Intel
+      manufacturer: SuperMicro
+      vendor: Silicon Mechanics
+      model: xxxxU 2U Ultra NVMe Server
+      os: Ubuntu 14.04 LTS
+      local_storage: "7TB @ /loc (?MB/s throughput / ? IOps)"
+      network: 10G (up to 1GB/s throughput)
+      gpu: NVIDIA
+      node_count: 42
+      partition: largenode
+    -  
       node_name: rhino
       cores: 14
       sockets: 2


### PR DESCRIPTION
Updated information in the cluster nodes table (`_data/cluster_nodes.yaml`) with J node information.  @bmcgough has this table published [here](https://sciwiki.fredhutch.org/scicomputing/compute_platforms/#gizmo)

I think this will close #138 