### PR TITLE
adding scicomp contact info

### DIFF
--- a/_scicomputing/comp_index.md
+++ b/_scicomputing/comp_index.md
@@ -6,9 +6,11 @@ primary_reviewers: vortexing
 Center IT supports a wide array of resources made available to researchers.  Much of the basic computing information needed on an ongoing basis can be found via Centernet and the Center IT pages.  However, much of the scientific computing resource documentation beyond this material is provided in this section of the Wiki, and links to existing resources and documentation are provided when available.  
 
 
-## [Help, Access and Credentials](/scicomputing/access_overview/)
+## [Access and Credentials](/scicomputing/access_overview/)
 This section includes a variety of information about accessing computing resources at the Fred Hutch, including managing credentials for services when required.  
-- To get help you can contact SciComp @ via email or you ask a public question on the fhbig slack channel.
+
+To get help you can email `SciComp` or you ask a public question on [The Coop's Slack Workspace](https://fhbig.slack.com/messages) in the `question-and-answer` channel.  
+
 - [Methods](/scicomputing/access_methods/)
 - [Credentials](/scicomputing/access_credentials/)
 

--- a/_scicomputing/comp_index.md
+++ b/_scicomputing/comp_index.md
@@ -1,13 +1,14 @@
 ---
 title: Overview of Scientific Computing at Fred Hutch
-last_modified_at: 2019-05-01
+last_modified_at: 2019-05-30
 primary_reviewers: vortexing
 ---
 Center IT supports a wide array of resources made available to researchers.  Much of the basic computing information needed on an ongoing basis can be found via Centernet and the Center IT pages.  However, much of the scientific computing resource documentation beyond this material is provided in this section of the Wiki, and links to existing resources and documentation are provided when available.  
 
 
-## [Access and Credentials](/scicomputing/access_overview/)
+## [Help, Access and Credentials](/scicomputing/access_overview/)
 This section includes a variety of information about accessing computing resources at the Fred Hutch, including managing credentials for services when required.  
+- To get help you can contact SciComp @ via email or you ask a public question on the fhbig slack channel.
 - [Methods](/scicomputing/access_methods/)
 - [Credentials](/scicomputing/access_credentials/)
 


### PR DESCRIPTION
just quick change which would allow me to put sciwiki into my email footer and not any other info about scicomp support 

I'd like to put this 

https://sciwiki.fredhutch.org/scicomputing/

instead of this 

https://sciwiki.fredhutch.org/scicomputing/comp_index/

into my footer but currently it does not redirect and gets a 404
