### PR TITLE
Scientific Computing reference section

### DIFF
--- a/_scicomputing/reference_overview.md
+++ b/_scicomputing/reference_overview.md
@@ -5,7 +5,7 @@ primary_reviewers: vortexing
 ---
 The rest of this wiki provides general guidelines and approaches to working with data at Fred Hutch. This reference section includes information on where to obtain training, as well as specific step-by-step tutorials for accomplishing tasks with Hutch resources.
 
-## [Training](/scicomputing/reference_training/)
+## [Training and Finding Help](/scicomputing/reference_training/)
 
 There are many opportunities for training (courses and tutorials) and connecting with coding communities. The Fred Hutch Bioinformatics and Data Science Cooperative (The Coop) and fredhutch.io offer events and meeting groups. Additional opportunities are available elsewhere in Seattle (at UW and through Meetup.com) and online.
 

--- a/_scicomputing/reference_overview.md
+++ b/_scicomputing/reference_overview.md
@@ -3,25 +3,16 @@ title: Overview of Reference and Announcements
 last_modified_at: 2019-04-01
 primary_reviewers: vortexing
 ---
-There are a variety of resources for training on various aspects of Bioinformatics and data skills available at the Fred Hutch, in the Seattle area as well as online resources.
+The rest of this wiki provides general guidelines and approaches to working with data at Fred Hutch. This reference section includes information on where to obtain training, as well as specific step-by-step tutorials for accomplishing tasks with Hutch resources.
 
-## Local Training and Resources
-- [fredhutch.io](http://www.fredhutch.io/) offers frequent, on campus courses on a topics such as R, python or GitHub, and information about previous and upcoming courses is on their site.  In order to sign up for courses, go to [MyHutch](https://fredhutch.okta.com/) and click on Hutch Learning to see currently available courses and register for them.  
-- [Bioinformatics Shared Resources](http://sharedresources.fhcrc.org/core-facilities/computational-biology) offers consultation on a variety of issues related to experimental design and bioinformatic analysis.
-- [Scientific Computing training materials](https://teams.fhcrc.org/sites/citwiki/SciComp/Training%20Materials/Forms/AllItems.aspx) (requires login), related to introduction to Unix and Gizmo, though additional, more recent, information can be see in the Computing section of this site.
-- FHBig (Fred Hutch Bioinformatics Interest Group), is a Fred Hutch based community group that has created the [FHBig website](https://fredhutch.github.io/FHBig/) and maintains a [slack workspace](https://fhbig.slack.com/, now referred to as The Coop Communities Slack) to support communication about data science among staff and researchers at the Hutch.  
-- [UW Biostatistics Summer Institutes](https://www.biostat.washington.edu/suminst) offer yearly intensive courses over the summers on a wide variety of topics.
+## [Training](/scicomputing/reference_training/)
 
-## Online Learning
-- [Biostar Handbook: A Beginner's Guide to Bioinformatics](https://www.biostarhandbook.com)
-- [CalTech](http://work.caltech.edu/telecourse) Learning from Data
-- [The Carpentries](https://carpentries.org), with lessons from [Data Carpentry](https://datacarpentry.org) and [Software Carpentry](https://software-carpentry.org/lessons/)
-- [Cognitive Class](https://cognitiveclass.ai): Data science and cognitive computing courses
-- [Coursera](https://www.datacamp.com), including courses on [Data Science](https://www.coursera.org/browse/data-science) and [Bioinforamtics](https://www.coursera.org/browse/life-sciences/bioinformatics)
-- [CodeAcademy](http://www.codecademy.com)
-- [DataCamp](https://www.datacamp.com)
-- [DataQuest](https://www.dataquest.io/home)
-- [edX](https://www.edx.org), including courses in [Data Analysis and Statistics](https://www.edx.org/course/subject/data-analysis-statistics) and [Bioinformatics](https://www.edx.org/learn/bioinformatics)
-- [The Open Source Data Science Masters](http://datasciencemasters.org)
-- [ROSALIND interactive bioinformatics problem set](http://rosalind.info/)
-- [Udacity](https://www.udacity.com) has courses on [Data Science](https://www.udacity.com/courses/school-of-data-science)
+There are many opportunities for training (courses and tutorials) and connecting with coding communities. The Fred Hutch Bioinformatics and Data Science Cooperative (The Coop) and fredhutch.io offer events and meeting groups. Additional opportunities are available elsewhere in Seattle (at UW and through Meetup.com) and online.
+
+## [Resource library](/computingdemos/)
+
+The Resource Library contains both links to GitHub repositories containing templates for coding projects and example code, as well as tutorials and demonstrations for accomplishing tasks with Hutch data science resources.
+
+## [Announcements](/scicompannounce)
+
+Scientific Computing sends email updates to their list of users about changes to software and hardware. Important announcements are also archived here.

--- a/_scicomputing/reference_overview.md
+++ b/_scicomputing/reference_overview.md
@@ -1,15 +1,15 @@
 ---
-title: Overview of How-To and Training
-last_modified_at: 20190-04-01
+title: Overview of Reference and Announcements
+last_modified_at: 2019-04-01
 primary_reviewers: vortexing
 ---
 There are a variety of resources for training on various aspects of Bioinformatics and data skills available at the Fred Hutch, in the Seattle area as well as online resources.
 
 ## Local Training and Resources
 - [fredhutch.io](http://www.fredhutch.io/) offers frequent, on campus courses on a topics such as R, python or GitHub, and information about previous and upcoming courses is on their site.  In order to sign up for courses, go to [MyHutch](https://fredhutch.okta.com/) and click on Hutch Learning to see currently available courses and register for them.  
-- [Bioinformatics Shared Resources](http://sharedresources.fhcrc.org/core-facilities/computational-biology)
+- [Bioinformatics Shared Resources](http://sharedresources.fhcrc.org/core-facilities/computational-biology) offers consultation on a variety of issues related to experimental design and bioinformatic analysis.
 - [Scientific Computing training materials](https://teams.fhcrc.org/sites/citwiki/SciComp/Training%20Materials/Forms/AllItems.aspx) (requires login), related to introduction to Unix and Gizmo, though additional, more recent, information can be see in the Computing section of this site.
-- FHBig (Fred Hutch Bioinformatics Interest Group), is a Fred Hutch based community group that has created the [FHBig website](https://fredhutch.github.io/FHBig/) and maintains a [slack workspace](https://fhbig.slack.com/) to support communication between staff at the Hutch.  
+- FHBig (Fred Hutch Bioinformatics Interest Group), is a Fred Hutch based community group that has created the [FHBig website](https://fredhutch.github.io/FHBig/) and maintains a [slack workspace](https://fhbig.slack.com/, now referred to as The Coop Communities Slack) to support communication about data science among staff and researchers at the Hutch.  
 - [UW Biostatistics Summer Institutes](https://www.biostat.washington.edu/suminst) offer yearly intensive courses over the summers on a wide variety of topics.
 
 ## Online Learning

--- a/_scicomputing/reference_training.md
+++ b/_scicomputing/reference_training.md
@@ -1,22 +1,70 @@
-title: Overview of Reference and Announcements
+title: Training and
 last_modified_at: 2019-04-01
 primary_reviewers: vortexing
 ---
 There are a variety of resources for training on various aspects of Bioinformatics and data skills available at the Fred Hutch, in the Seattle area and online.
 
-## [Training](/scicomputing/reference_training/)
+## At FredHutch
 
-### At FredHutch
-- [fredhutch.io](http://www.fredhutch.io/) offers frequent, on campus courses on a topics such as R, python or GitHub, and information about previous and upcoming courses is on their site.  In order to sign up for courses, go to [MyHutch](https://fredhutch.okta.com/) and click on Hutch Learning to see currently available courses and register for them.  
-- [Bioinformatics Shared Resources](http://sharedresources.fhcrc.org/core-facilities/computational-biology) offers consultation on a variety of issues related to experimental design and bioinformatic analysis.
-- [Scientific Computing training materials](https://teams.fhcrc.org/sites/citwiki/SciComp/Training%20Materials/Forms/AllItems.aspx) (requires login), related to introduction to Unix and Gizmo, though additional, more recent, information can be see in the Computing section of this site.
-- FHBig (Fred Hutch Bioinformatics Interest Group), is a Fred Hutch based community group that has created the [FHBig website](https://fredhutch.github.io/FHBig/) and maintains a [slack workspace](https://fhbig.slack.com/, now referred to as The Coop Communities Slack) to support communication about data science among staff and researchers at the Hutch.  
+### Courses
 
-### Seattle area training
+[fredhutch.io](http://www.fredhutch.io/) offers frequent, on campus courses on a topics such as R, python or GitHub, and information about previous and upcoming courses is on their site.  In order to sign up for courses, go to [MyHutch](https://fredhutch.okta.com/) and click on Hutch Learning to see currently available courses and register for them. fredhutch.io also helps coordinate additional events and specialized classes in collaboration with The Coop (see below).
+
+### Community Groups
+
+[The Coop](https://centernet.fredhutch.org/cn/u/bdsc.html) (link requires login) is the Fred Hutch Bioinformatics and Data Science Cooperative, and works to share information and resources about computational work across the Hutch. The Coop maintains a listserv, calendars of data science events, and The Coop Communities Slack](https://fhbig.slack.com/). [FHBig](https://fredhutch.github.io/FHBig/) is the Fred Hutch Bioinformatics Interest Group, a community-based group that hosts a [blog](https://fredhutch.github.io/FHBig/year-archive/) and facilitates information sharing among the bioinformatics research community at the Hutch. Hutch employees can learn more through the links above or by emailing `coophelp`.
+
+The Coop and FHBig also support community groups that meet regularly to discuss topics in reproducible computational methods. To learn more about what to expect from these meetings, please visit [our Community Groups GitHub repository](https://github.com/FredHutch/community_groups). Current meeting schedules and locations are available on the [Google calendar](https://calendar.google.com/calendar/r?cid=Z2QzMGRsaWZyaTRmdTdoMTA0Y3VxZGowZGdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
+
+- **Data visualization group:**  
+
+- **Python coding group:**
+
+- **R coding group:**
+
+- **Software design group:**
+
+### Office Hours
+
+Several groups on campus host weekly or monthly office hours to provide assistance on computational tasks. Please visit Centernet or the [Google calendar](https://calendar.google.com/calendar/r?cid=Z2QzMGRsaWZyaTRmdTdoMTA0Y3VxZGowZGdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) for current scheduling, locations, and contact information.
+
+- **Bioinformatics (Shared Resources)** offers consultation on a variety of issues related to experimental design and bioinformatic analysis. They are able to answer questions on topics including: experimental design, exploring data visually (e.g., IGV, Loupe Cell Browser), generating figures for manuscripts, and developing customized workflows for unique problems. See the [Shared Resources website](http://sharedresources.fhcrc.org/core-facilities/computational-biology) for more information, and email `bioinformatics` to make sure there is time/space available during their scheduled events.
+
+Data Ethics/Compliance/Security: Am I managing my data securely? What resources are available at the Hutch for data security compliance?
+
+Information Security Office (ISO)
+Hutch Data Commonwealth (HDC) Compliance
+
+Data Science/Software Engineers: HDC houses teams of Data Scientists and Software Developers.
+
+Questions: How can I improve my data management? How can I apply machine learning to my dataset?
+
+Fredhutch.io: trains researchers in reproducible computational methods
+
+Questions: Where should I get started with programming? What resources are available at the Hutch for computational training? I just started programming and can't debug my code! Help!
+
+REDcap: REDCap is a secure web application for building and managing online surveys and databases. What can REDCap do? How can I make REDCap do something (or stop doing something)?
+
+REDCap is a secure web application for building and managing online surveys and databases.
+
+SciComp General Consulting: How do I access and use shared computational resources at the Hutch? Why are my scripts not working on the cluster? How can I use this new R/python package on the cluster?
+
+Scientific Computing manages basic account, storage, and cluster use
+
+SciComp New Technologies: How can I start building analytical pipelines in the cloud? How can I making my computation more scalable and reproducible?
+
+Next generation and cloud computing
+
+
+
+## In Seattle
+
 - [UW Biostatistics Summer Institutes](https://www.biostat.washington.edu/suminst) offer yearly intensive courses over the summers on a wide variety of topics.
+- [Meetup](https://www.meetup.com) hosts various coding groups that meet regularly to share skills and provide networking opportunities. [RLadies Seattle](https://www.meetup.com/rladies-seattle/) and [Seattle UseR](https://www.meetup.com/Seattle-useR/) both include leaders from Fred Hutch.
 
 
-### Online Learning
+## Online Learning
+
 - [Biostar Handbook: A Beginner's Guide to Bioinformatics](https://www.biostarhandbook.com)
 - [CalTech](http://work.caltech.edu/telecourse) Learning from Data
 - [The Carpentries](https://carpentries.org), with lessons from [Data Carpentry](https://datacarpentry.org) and [Software Carpentry](https://software-carpentry.org/lessons/)

--- a/_scicomputing/reference_training.md
+++ b/_scicomputing/reference_training.md
@@ -1,3 +1,4 @@
+---
 title: Training and Finding Help
 last_modified_at: 2019-04-01
 primary_reviewers: vortexing

--- a/_scicomputing/reference_training.md
+++ b/_scicomputing/reference_training.md
@@ -12,17 +12,17 @@ There are a variety of resources for training on various aspects of Bioinformati
 
 ### Community Groups
 
-[The Coop](https://centernet.fredhutch.org/cn/u/bdsc.html) (link requires login) is the Fred Hutch Bioinformatics and Data Science Cooperative, and works to share information and resources about computational work across the Hutch. The Coop maintains a listserv, calendars of data science events, and The Coop Communities Slack](https://fhbig.slack.com/). [FHBig](https://fredhutch.github.io/FHBig/) is the Fred Hutch Bioinformatics Interest Group, a community-based group that hosts a [blog](https://fredhutch.github.io/FHBig/year-archive/) and facilitates information sharing among the bioinformatics research community at the Hutch. Hutch employees can learn more through the links above or by emailing `coophelp`.
+[The Coop](https://centernet.fredhutch.org/cn/u/bdsc.html) (link requires login) is the Fred Hutch Bioinformatics and Data Science Cooperative, and works to share information and resources about computational work across the Hutch. The Coop maintains a listserv, calendars of data science events, and [The Coop Communities Slack](https://fhbig.slack.com/). [FHBig](https://fredhutch.github.io/FHBig/) is the Fred Hutch Bioinformatics Interest Group, a community-based group that hosts a [blog](https://fredhutch.github.io/FHBig/year-archive/) and facilitates information sharing among the bioinformatics research community at the Hutch. Hutch employees can learn more through the links above or by emailing `coophelp`.
 
 The Coop and FHBig also support community groups that meet regularly to discuss topics in reproducible computational methods. To learn more about what to expect from these meetings, please visit [our Community Groups GitHub repository](https://github.com/FredHutch/community_groups). Current meeting schedules and locations are available on the [Google calendar](https://calendar.google.com/calendar/r?cid=Z2QzMGRsaWZyaTRmdTdoMTA0Y3VxZGowZGdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
 
-- **Data visualization group:**  
+- **Data visualization group:** Develops visualizations from data released by [TidyTuesday](https://thomasmock.netlify.com/post/tidytuesday-a-weekly-social-data-project-in-r/); see #data-viz on [The Coop Communities Slack](https://fhbig.slack.com/)
 
-- **Python coding group:**
+- **Python coding group:** TBA, see #python-user-comm on [The Coop Communities Slack](https://fhbig.slack.com/)
 
-- **R coding group:**
+- **R coding group:** Discusses R packages and troubleshoots code of participants; see #r-user-comm on [The Coop Communities Slack](https://fhbig.slack.com/)
 
-- **Software design group:**
+- **Software design group:** Discusses issues in software engineering and interface design, invites speakers on specific topics and participants share their coding projects; see #software-engineers on [The Coop Communities Slack](https://fhbig.slack.com/)
 
 ### Office Hours
 
@@ -30,32 +30,17 @@ Several groups on campus host weekly or monthly office hours to provide assistan
 
 - **Bioinformatics (Shared Resources)** offers consultation on a variety of issues related to experimental design and bioinformatic analysis. They are able to answer questions on topics including: experimental design, exploring data visually (e.g., IGV, Loupe Cell Browser), generating figures for manuscripts, and developing customized workflows for unique problems. See the [Shared Resources website](http://sharedresources.fhcrc.org/core-facilities/computational-biology) for more information, and email `bioinformatics` to make sure there is time/space available during their scheduled events.
 
-Data Ethics/Compliance/Security: Am I managing my data securely? What resources are available at the Hutch for data security compliance?
+- **Data Ethics/Compliance/Security:** Staff from the Information Security Office (ISO) and Hutch Data Commonwealth (HDC) Compliance Office are available to answer questions related to secure data management and resources at the Hutch for security compliance.
 
-Information Security Office (ISO)
-Hutch Data Commonwealth (HDC) Compliance
+- **Data Science/Software Engineers:** Hutch Data Commonwealth (HDC) employs teams of Data Scientists and Software Developers, who are available to answer questions related to general data management and application of common data science tools (like machine learning) to research questions.
 
-Data Science/Software Engineers: HDC houses teams of Data Scientists and Software Developers.
+- **Fredhutch.io:** [fredhutch.io](http://www.fredhutch.io/) trains researchers in reproducible computational methods. Staff are available to assist researchers in getting started with coding and orienting staff to resources for improving their coding, including troubleshooting application of code to research questions.
 
-Questions: How can I improve my data management? How can I apply machine learning to my dataset?
+- **REDcap:** [REDCap](http://research.fhcrc.org/cds/en/redcap.html) is a secure web application for building and managing online surveys and databases and is managed by Collaborative Data Services (CDS) at Fred Hutch. Staff are available to answer questions related to REDCap functionality and troubleshooting.
 
-Fredhutch.io: trains researchers in reproducible computational methods
+- **SciComp General Consulting:** Scientific Computing (SciComp) is the group in Hutch Data Commonwealth (HDC) that manages basic account access for research computing resources, including data storage and shared computational cluster use. Staff are available to answer questions related to access and usage of Hutch resources for computational research.
 
-Questions: Where should I get started with programming? What resources are available at the Hutch for computational training? I just started programming and can't debug my code! Help!
-
-REDcap: REDCap is a secure web application for building and managing online surveys and databases. What can REDCap do? How can I make REDCap do something (or stop doing something)?
-
-REDCap is a secure web application for building and managing online surveys and databases.
-
-SciComp General Consulting: How do I access and use shared computational resources at the Hutch? Why are my scripts not working on the cluster? How can I use this new R/python package on the cluster?
-
-Scientific Computing manages basic account, storage, and cluster use
-
-SciComp New Technologies: How can I start building analytical pipelines in the cloud? How can I making my computation more scalable and reproducible?
-
-Next generation and cloud computing
-
-
+- **SciComp New Technologies:** In addition to general consulting (see above), Scientific Computing (SciComp) supports researchers interested in emerging technologies like next generation sequencing and cloud computing. Staff are available to answer questions about getting started building analytical pipelines in the cloud, and generally making computation more scalable and reproducible.
 
 ## In Seattle
 

--- a/_scicomputing/reference_training.md
+++ b/_scicomputing/reference_training.md
@@ -1,0 +1,31 @@
+title: Overview of Reference and Announcements
+last_modified_at: 2019-04-01
+primary_reviewers: vortexing
+---
+There are a variety of resources for training on various aspects of Bioinformatics and data skills available at the Fred Hutch, in the Seattle area and online.
+
+## [Training](/scicomputing/reference_training/)
+
+### At FredHutch
+- [fredhutch.io](http://www.fredhutch.io/) offers frequent, on campus courses on a topics such as R, python or GitHub, and information about previous and upcoming courses is on their site.  In order to sign up for courses, go to [MyHutch](https://fredhutch.okta.com/) and click on Hutch Learning to see currently available courses and register for them.  
+- [Bioinformatics Shared Resources](http://sharedresources.fhcrc.org/core-facilities/computational-biology) offers consultation on a variety of issues related to experimental design and bioinformatic analysis.
+- [Scientific Computing training materials](https://teams.fhcrc.org/sites/citwiki/SciComp/Training%20Materials/Forms/AllItems.aspx) (requires login), related to introduction to Unix and Gizmo, though additional, more recent, information can be see in the Computing section of this site.
+- FHBig (Fred Hutch Bioinformatics Interest Group), is a Fred Hutch based community group that has created the [FHBig website](https://fredhutch.github.io/FHBig/) and maintains a [slack workspace](https://fhbig.slack.com/, now referred to as The Coop Communities Slack) to support communication about data science among staff and researchers at the Hutch.  
+
+### Seattle area training
+- [UW Biostatistics Summer Institutes](https://www.biostat.washington.edu/suminst) offer yearly intensive courses over the summers on a wide variety of topics.
+
+
+### Online Learning
+- [Biostar Handbook: A Beginner's Guide to Bioinformatics](https://www.biostarhandbook.com)
+- [CalTech](http://work.caltech.edu/telecourse) Learning from Data
+- [The Carpentries](https://carpentries.org), with lessons from [Data Carpentry](https://datacarpentry.org) and [Software Carpentry](https://software-carpentry.org/lessons/)
+- [Cognitive Class](https://cognitiveclass.ai): Data science and cognitive computing courses
+- [Coursera](https://www.datacamp.com), including courses on [Data Science](https://www.coursera.org/browse/data-science) and [Bioinforamtics](https://www.coursera.org/browse/life-sciences/bioinformatics)
+- [CodeAcademy](http://www.codecademy.com)
+- [DataCamp](https://www.datacamp.com)
+- [DataQuest](https://www.dataquest.io/home)
+- [edX](https://www.edx.org), including courses in [Data Analysis and Statistics](https://www.edx.org/course/subject/data-analysis-statistics) and [Bioinformatics](https://www.edx.org/learn/bioinformatics)
+- [The Open Source Data Science Masters](http://datasciencemasters.org)
+- [ROSALIND interactive bioinformatics problem set](http://rosalind.info/)
+- [Udacity](https://www.udacity.com) has courses on [Data Science](https://www.udacity.com/courses/school-of-data-science)

--- a/_scicomputing/reference_training.md
+++ b/_scicomputing/reference_training.md
@@ -1,4 +1,4 @@
-title: Training and
+title: Training and Finding Help
 last_modified_at: 2019-04-01
 primary_reviewers: vortexing
 ---


### PR DESCRIPTION
- updated overview page to reflect categories contained
- moved content on training to new page, added info on community groups and office hours

Not sure if I got the links to other pages correct? Happy to make changes as necessary.