### PR TITLE
Updating navigation and descriptions on overviews

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -104,10 +104,10 @@ scicomputing:
     children:
       - title: "Overview"
         url: /scicomputing/access_overview/
-      - title: "Methods"
-        url: /scicomputing/access_methods/
       - title: "Credentials"
         url: /scicomputing/access_credentials/
+      - title: "Methods"
+        url: /scicomputing/access_methods/
 
   - title: "Data Storage"
     children:
@@ -128,14 +128,8 @@ scicomputing:
     children:
       - title: "Overview"
         url: /scicomputing/software_overview/
-      - title: "Getting Started"
-        url: /scicomputing/software_languages/
-      - title: "R, RStudio"
-        url: /scicomputing/software_R/
-      - title: "Python"
-        url: /scicomputing/software_python/
-      - title: "Linux, Unix and Bash"
-        url: /scicomputing/software_linux101/
+      - title: "Common Languages"
+        url: /scicomputing/software_languages/     
       - title: "Managing and Sharing Code"
         url: /scicomputing/software_managecode/
       - title: "Software Development Standards"
@@ -145,6 +139,8 @@ scicomputing:
     children:
       - title: "Overview"
         url: /scicomputing/compute_overview/
+      - title: "Quick Start Guide"
+        url: /scicomputing/compute_quickstart/
       - title: "Technologies"
         url: /scicomputing/compute_platforms/
       - title: "Computing Environments and Containers"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -36,7 +36,7 @@ generation:
         url: /generation/study_overview/
       - title: "Proposals and Funding"
         url: /generation/study_proposal/
-      - title: "Hypothesis Development and Big Molecular Data"
+      - title: "Hypotheses and Molecular Data"
         url: /generation/study_hypothesis/
       - title: "Multiple Testing"
         url: /generation/multiple_testing/
@@ -45,7 +45,7 @@ generation:
     children:
       - title: "Overview"
         url: /generation/human_overview/
-      - title: "Consenting and Big Molecular Data"
+      - title: "Consenting and IRB"
         url: /generation/human_consentIRB/
       - title: "Data Privacy and Security"
         url: /generation/human_privacySecurity/

--- a/_generation/gen_index.md
+++ b/_generation/gen_index.md
@@ -13,40 +13,17 @@ Upfront consideration to the design and execution of large scale data generating
 This section provides guidance for researchers looking to develop a hypothesis that will have reasonable statistical power, identify the appropriate set of samples, and execute a large scale data production from those samples.  There are the two general types of studies using large scale molecular data sets, which can loosely be thought of as "investigative" and "comparative."  The two aren't completely extricable and can each can serve as groundwork for future experiments for the other.  The process to perform these types of studies, however, can be very different.  The details specific to each study type are best addressed prior to generating materials or data sets.  
 
 
-* [Proposals and Funding]({{ site.baseurl }}/generation/study_proposal/)
-* [Hypothesis Development and Big Molecular Data]({{ site.baseurl }}/generation/study_hypothesis/)
-* [Multiple Testing](/generation/multiple_testing/)
-
-
 ## [Consent, Privacy and Security]({{ site.baseurl }}/generation/human_overview/)
 The policies and processes that relate to the human subject components of any large scale data generating or analyzing study are continually evolving as new issues arise and become more clear.  Keeping up with the particular issues that do or do not apply to a given research project can sometimes be a challenge, and these pages contain relevant guidance and links to the necessary information researchers need before, during and after a research project involving human specimens or data.  
 
-* [Consenting and Big Molecular Data]({{ site.baseurl }}/generation/human_consentIRB/)
-* [Data Privacy and Security]({{ site.baseurl }}/generation/human_privacySecurity/)
-* [Compliance and Legal Agreements]({{ site.baseurl }}/generation/security_legal/)
-* [De-identification]({{ site.baseurl }}/generation/human_deidentification/)
-* [Data Sharing and Public Repositories]({{ site.baseurl }}/generation/human_shareDeposits/)
 
 ## [Clinical and Experimental Data]({{ site.baseurl }}/generation/clsp_overview/)
 For a each study, the particular covariates associated with large scale data sets typically come from clinical or laboratory data. When these data are originating from human samples, certain protections need to be in place to ensure patient privacy.  There are resources at the Fred Hutch which can help researchers effectively manage these data so that they can be associated with downstream molecular data sets more consistently and securely.  
 
 
-* [Clinical Data]({{ site.baseurl }}/generation/clsp_clinicalCov/)
-* [Specimen Banking]({{ site.baseurl }}/generation/clsp_specimenBanking/)
-* [Experimental Data]({{ site.baseurl }}/generation/clsp_labCov/)
-
 ## [Large-Scale Data Generation]({{ site.baseurl }}/generation/datagen_overview/)
 The decisions required when generating large scale data sets themselves are informed by an understanding of the specimen cohort, any limitations imposed by the consent of the patients from which those specimens were obtained, and the specific hypothesis the researcher is intending to address.  This section contains guidance about generating or handling large scale data from a variety of sources, highlights the particularites of each, and include information for researchers interacting with various Fred Hutch Shared Resources.  
 
-* [Genomics Data]({{ site.baseurl }}/generation/datagen_platformsData/)
-* [Flow Cytometry Data]({{ site.baseurl }}/generation/datagen_flowcytometry/)
-* [Imaging Data]({{ site.baseurl }}/generation/datagen_imaging/)
-* [Proteomics Data]({{ site.baseurl }}/generation/datagen_proteomics/)
 
 ## [Other Laboratory Resources]({{ site.baseurl }}/generation/labman_overview/)
 Some of the challenges associated with executing large scale data projects can be mitigated by implementing good laboratory management and data systems before beginning the project.  These sections relate to the particular systems available to Fred Hutch researchers that help them manage data generated in laboratories and also specific types of guidance about good laboratory practices with large scale data generation in mind.
-
-* [Assay Material Prep and QC]({{ site.baseurl }}/generation/datagen_assayPrep/)
-* [DNA-Based Approaches]({{ site.baseurl }}/generation/datagen_dnaApproaches/)
-* [RNA-Based Approaches]({{ site.baseurl }}/generation/datagen_dnaApproaches/)
-* [Support Software]({{ site.baseurl }}/generation/labman_software/)

--- a/_scicomputing/comp_index.md
+++ b/_scicomputing/comp_index.md
@@ -11,42 +11,18 @@ This section includes a variety of information about accessing computing resourc
 
 To get help you can email `SciComp` or you ask a public question on [The Coop's Slack Workspace](https://fhbig.slack.com/messages) in the `question-and-answer` channel.  
 
-- [Methods](/scicomputing/access_methods/)
-- [Credentials](/scicomputing/access_credentials/)
-
 
 ## [Data Storage](/scicomputing/store_overview/)
 The Hutch, through Center IT and Scientific Computing, support a number of options for storing your data. The service you use to store your data will depend on the nature of the data and the anticipated use.
-
-- [Database Systems](/scicomputing/store_databases/)
-- [File Storage Systems](/scicomputing/store_posix/)
-- [Object Storage Systems](/scicomputing/store_objectstore/)
-- [Temporary Storage: Scratch](/scicomputing/store_scratch/)
-- [Collaborative Storage Systems](/scicomputing/store_collaboration/)
 
 
 ## [Software Development](/scicomputing/software_overview/)
 While there are many types of programming languages various software used in scientific research are written in, there are a handful of specific languages that are commonly used in the process of doing a wide range of research tasks. We will introduce the most common here.
 
-- [Getting Started](/scicomputing/software_languages/)
-- [R, RStudio](/scicomputing/software_R/)
-- [Python](/scicomputing/software_python/)
-- [Linux, Unix and Bash](/scicomputing/software_linux101/)
-- [Managing and Sharing Code](/scicomputing/software_managecode/)
-- [Software Development Standards](/scicomputing/software_standards/)
-
 
 ## [Large Scale Compute](/scicomputing/compute_overview/)
 This section contains articles that describe a range of high performance computing resource options available to Fred Hutch researchers.
 
-- [Technologies](/scicomputing/compute_platforms/)
-- [Computing Environments and Containers](/scicomputing/compute_environments/)
-- [Job Management](/scicomputing/compute_jobs/)
-- [Parallel Computing](/scicomputing/compute_parallel/)
-- [Cloud Computing](/scicomputing/compute_cloud/)
-- [Information for Grant Writers](/scicomputing/compute_grants/)
 
 ## [Reference Material](/scicomputing/reference_overview/)
 We maintain a space for both announcements from Scientific Computing as well as a Resource Library at the following links:
-- [Resource Library](/compdemos/)
-- [Announcements](/scicompannounce/)

--- a/_scicomputing/comp_index.md
+++ b/_scicomputing/comp_index.md
@@ -3,13 +3,11 @@ title: Overview of Scientific Computing at Fred Hutch
 last_modified_at: 2019-05-30
 primary_reviewers: vortexing
 ---
-Center IT supports a wide array of resources made available to researchers.  Much of the basic computing information needed on an ongoing basis can be found via Centernet and the Center IT pages.  However, much of the scientific computing resource documentation beyond this material is provided in this section of the Wiki, and links to existing resources and documentation are provided when available.  
+Various groups support computational capacity at the Hutch. Center IT supports general computing tasks, such as email and desktop computer software; further information can be found on the Center IT pages in Centernet. This section of the Wiki represents information relating to research and scientific computing, which generally require additional software, hardware, and skills. If you have questions that aren't answered here, please email `SciComp` or ask a public question on [The Coop's Slack Workspace](https://fhbig.slack.com/messages) in the `question-and-answer` channel. 
 
 
 ## [Access and Credentials](/scicomputing/access_overview/)
-This section includes a variety of information about accessing computing resources at the Fred Hutch, including managing credentials for services when required.  
-
-To get help you can email `SciComp` or you ask a public question on [The Coop's Slack Workspace](https://fhbig.slack.com/messages) in the `question-and-answer` channel.  
+This section includes a variety of information about accessing computing resources at the Fred Hutch, including managing credentials for services when required.   
 
 
 ## [Data Storage](/scicomputing/store_overview/)
@@ -17,12 +15,12 @@ The Hutch, through Center IT and Scientific Computing, support a number of optio
 
 
 ## [Software Development](/scicomputing/software_overview/)
-While there are many types of programming languages various software used in scientific research are written in, there are a handful of specific languages that are commonly used in the process of doing a wide range of research tasks. We will introduce the most common here.
+Researchers at the Hutch use reproducible computational methods to perform research and share their findings with the broader community. These methods include writing computer code and producing software in various coding languages. This section describes some common languages and tools, as well as recommended best practices, for writing code.
 
 
-## [Large Scale Compute](/scicomputing/compute_overview/)
-This section contains articles that describe a range of high performance computing resource options available to Fred Hutch researchers.
+## [Large Scale Computing](/scicomputing/compute_overview/)
+The Hutch supports both local compute clusters as well as cloud computing for researchers. This section describes available technology and how to use these resources.
 
 
-## [Reference Material](/scicomputing/reference_overview/)
-We maintain a space for both announcements from Scientific Computing as well as a Resource Library at the following links:
+## [Reference and Announcements](/scicomputing/reference_overview/)
+This section includes links to training opportunities, office hours, and community groups for computational support, as well as a resource library of code and tutorials and announcements from Scientific Computing.


### PR DESCRIPTION
Addresses #348 by cross checking the sidebar subheadings across current page content. Includes Quick Start Guide from #368 so subheadings will still be complete when that's merged.

Additional changes: Includes a few minor updates to some subheadings to improve readability. Also removes the subheadings from the Data Generation and Scientific Computing overviews (so we don't need to update things in two places). Revised the summaries on the latter, given the subheadings are no longer present. 