### PR TITLE
Fix link for howtoRhino page

### DIFF
--- a/_scicomputing/compute_platforms.md
+++ b/_scicomputing/compute_platforms.md
@@ -26,7 +26,7 @@ Beagle | Via Rhino or NoMachine hosts (CLI, FH credentials on campus/VPN off cam
 `Rhino`, or more specifically the `Rhinos`, are three locally managed HPC servers all accessed via the name `rhino`. Together, they function as a data and compute hub for a variety of data storage resources and high performance computing (HPC) such as those in the table above. The specific guidance for the use of each of the approaches to HPC access are slightly different, but will all require the user to learn how to access and interact with `rhino`.
 
 More information on the topic of ssh configurations for access to `rhino` can be found [here.](/scicomputing/access_methods/)
-More information on specific guidance for using `rhino` and `gizmo` are in our Resource Library for [`rhino`](/scicomputing/howtoRhino/) and for [`gizmo`](/compdemos/howtoGizmo/).
+More information on specific guidance for using `rhino` and `gizmo` are in our Resource Library for [`rhino`](/compdemos/howtoRhino/) and for [`gizmo`](/compdemos/howtoGizmo/).
 
 
 ### Gizmo and Beagle Cluster


### PR DESCRIPTION
`howtoRhino.md` and `howtoGizmo.md` are both in `_compdemos/` but the Rhino link pointed to the `_scicomputing/` dir instead. I fixed the link, but it's possible that both files are in the wrong directory instead.