### PR TITLE
deleted Software Dev group stuff and renamed Py Group

### DIFF
--- a/_scicomputing/reference_training.md
+++ b/_scicomputing/reference_training.md
@@ -24,11 +24,9 @@ The Coop and FHBig also support community groups that meet regularly to discuss 
 
 - **Nextflow group:** Discusses issues related to the use of Nextflow (and other workflow managers like Cromwell) at Fred Hutch. The group welcomes Nextflow users of all levels of expertise as well as those just learning about the tool. See the #nextflow channel on [The Coop Communities Slack](https://fhbig.slack.com/) for more information.
 
-- **Python coding group:** Discusses methods of programming in Python and troubleshoots code of participants. Python coders of all levels of expertise are welcome. See the #python-user-comm channel on [The Coop Communities Slack](https://fhbig.slack.com/) for more information.
+- **Python User Group:** Discusses methods of programming in Python and troubleshoots code of participants. Python coders of all levels of expertise are welcome. See the #python-user-comm channel on [The Coop Communities Slack](https://fhbig.slack.com/) for more information.
 
 - **R coding group:** Discusses R packages, R code and troubleshoots code of participants. R coders of all levels of expertise are welcome. See the #r-user-comm channel on [The Coop Communities Slack](https://fhbig.slack.com/) for more information.
-
-- **Software design group:** Discusses issues related to software engineering and interface design and invites speakers on specific topics and participants to share their coding projects. This group is not focused on a specific programming language, but rather on issues common across software projects. See the #software-engineers channel on [The Coop Communities Slack](https://fhbig.slack.com/) for more information.
 
 - **Technology Exchange:** Informal learning forum for employees in technology-focused jobs to share technical skills. This group is most appropriate for individuals who want to discuss the technical details of tools commonly used in positions focused on administration and infrastructure. However, anyone is welcome to attend this forum, and many topics will be relevant to researchers in positions that require technical skills. Subscribe to the [TechExchange mailing list](https://lists.fhcrc.org/mailman/listinfo/techexchange) for more information.
 

--- a/_scicomputing/reference_training.md
+++ b/_scicomputing/reference_training.md
@@ -18,15 +18,15 @@ There are a variety of resources for training on various aspects of bioinformati
 
 The Coop and FHBig also support community groups that meet regularly to discuss topics ranging from basic data literacy skill building to reproducible computational methods. To learn more about what to expect from these meetings, please visit [our Community Groups GitHub repository](https://github.com/FredHutch/community_groups). Current meeting schedules and locations are available on the [Google calendar](https://calendar.google.com/calendar/r?cid=Z2QzMGRsaWZyaTRmdTdoMTA0Y3VxZGowZGdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
 
-- **Coop community meetings:** The Coop hosts community meetings once a quarter to share information from the data science community at the Hutch. Join us to learn about projects and events happening in our community!
+- **Coop Community Meetings:** The Coop hosts community meetings once a quarter to share information from the data science community at the Hutch. Join us to learn about projects and events happening in our community!
 
-- **Data visualization group:** Develops visualizations from data released by [TidyTuesday](https://thomasmock.netlify.com/post/tidytuesday-a-weekly-social-data-project-in-r/). All programming languages (and even non-coders!) are welcome. See the #data-viz channel on [The Coop Communities Slack](https://fhbig.slack.com/) for more information.
+- **Data Visualization Group:** Develops visualizations from data released by [TidyTuesday](https://thomasmock.netlify.com/post/tidytuesday-a-weekly-social-data-project-in-r/). All programming languages (and even non-coders!) are welcome. See the #data-viz channel on [The Coop Communities Slack](https://fhbig.slack.com/) for more information.
 
-- **Nextflow group:** Discusses issues related to the use of Nextflow (and other workflow managers like Cromwell) at Fred Hutch. The group welcomes Nextflow users of all levels of expertise as well as those just learning about the tool. See the #nextflow channel on [The Coop Communities Slack](https://fhbig.slack.com/) for more information.
+- **Nextflow User Group:** Discusses issues related to the use of Nextflow (and other workflow managers like Cromwell) at Fred Hutch. The group welcomes Nextflow users of all levels of expertise as well as those just learning about the tool. See the #nextflow channel on [The Coop Communities Slack](https://fhbig.slack.com/) for more information.
 
 - **Python User Group:** Discusses methods of programming in Python and troubleshoots code of participants. Python coders of all levels of expertise are welcome. See the #python-user-comm channel on [The Coop Communities Slack](https://fhbig.slack.com/) for more information.
 
-- **R coding group:** Discusses R packages, R code and troubleshoots code of participants. R coders of all levels of expertise are welcome. See the #r-user-comm channel on [The Coop Communities Slack](https://fhbig.slack.com/) for more information.
+- **R User Group:** Discusses R packages, R code and troubleshoots code of participants. R coders of all levels of expertise are welcome. See the #r-user-comm channel on [The Coop Communities Slack](https://fhbig.slack.com/) for more information.
 
 - **Technology Exchange:** Informal learning forum for employees in technology-focused jobs to share technical skills. This group is most appropriate for individuals who want to discuss the technical details of tools commonly used in positions focused on administration and infrastructure. However, anyone is welcome to attend this forum, and many topics will be relevant to researchers in positions that require technical skills. Subscribe to the [TechExchange mailing list](https://lists.fhcrc.org/mailman/listinfo/techexchange) for more information.
 


### PR DESCRIPTION
deleted the info about the software development group as it's going away and renamed the python coding group to Python User Group