### PR TITLE
Fix link to https://tower.nf

### DIFF
--- a/_compdemos/nextflow.md
+++ b/_compdemos/nextflow.md
@@ -216,13 +216,13 @@ It is generally reasonable to just pick one and use it for everything, switching
 **Is there a better way to monitor a running workflow?**
 
 While you *can* just watch the output on the command line to see how your workflow is progressing, another great option is to use a service called Nextflow Tower.
-If you set up Nextflow Tower *before* starting a workflow, then you will be able to log in to [tower.nf](tower.nf) and see how your workflow is progressing. 
+If you set up Nextflow Tower *before* starting a workflow, then you will be able to log in to [tower.nf](https://tower.nf) and see how your workflow is progressing. 
 Nextflow Tower is a service set up and maintained by the developers of Nextflow.
 Keep in mind that this service is not hosted by Fred Hutch, and so you have to trust a third-party system to keep your data safe. 
 **It is not advised to user Nextflow Tower with sensitive or private information.**
 That said, only the metadata describing a given task is sent to Tower, not the actual data being analyzed.
 
-To get set up, go to [tower.nf](tower.nf) and follow their instructions. 
+To get set up, go to [tower.nf](https://tower.nf) and follow their instructions. 
 This setup will consist of verifying your email address, and then copying some configuration information into your Nextflow configuration file. 
 
 **Gottcha**: Make sure that you are using Nextflow version 19.10.0 or later.


### PR DESCRIPTION
I made a mistake on the Nextflow FAQ PR and didn't include the full URL to https://tower.nf

This PR should fix that and enable the links that are currently live on the wiki.