### PR TITLE
Fixed local wiki build.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development, :test do
   gem 'jekyll-gist', '~> 1.5.0'
   gem 'jekyll-remote-theme', '~> 0.3.0'
   gem 'jemoji', '~> 0.10.0'
-  gem 'html-proofer', '~> 3.9.0'
+  gem 'html-proofer', '~> 3.14.0'
   gem 'rake', '~> 12.3.0'
+  gem 'faraday', '~> 0.17'
 end

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ it can be found [here](https://www.ruby-lang.org/en/downloads/).
    
 1. You may need to install gems used by the site.
    Type `gem install -g Gemfile` to install all of the gems the site uses.
+   - If you get an error `mkmf.rb can't find the headers for ruby at /some/path/to/ruby.h` or something very similar, you need to install the `ruby-dev` package.
+   - If you get an error that `zlib is missing` you need to install the `zlib1g-dev` package.
 
 1. To build and view the site locally, from the cloned repo directory run
    `bundle install` then run `bundle exec jekyll serve`. Once the


### PR DESCRIPTION
Dependency conflict between html-proofer and nokogiri resolved by updating html-proofer to highest version with common nokogiri version dependency.  Also fixed issue with Faraday incompatibility by pinning faraday based on [this](https://github.com/github/personal-website/issues/166). 

Updated README with some extra information on how to resolve various local build errors that I encountered when building on a clean system under WSL.

Would be helpful if someone else could try building this locally (ideally under Max and Linux) and verify that it works.