### PR TITLE
Add snippets about invalid account errors for new users

### DIFF
--- a/_compdemos/first_rhino.md
+++ b/_compdemos/first_rhino.md
@@ -106,7 +106,7 @@ to enter your password and access `rhino`.
 ## Logging on to `gizmo` via `grabnode`
 
 When you log on to the cluster,
-all commands you run are limited by the compute resources associated with your default login
+all commands you run are limited by the compute resources associated with your PI.
 (and by the cluster being shared by many people!).
 It's good etiquette, and often a necessity,
 to request your own node for additional tasks.
@@ -130,6 +130,7 @@ If you aren't sure you need more than one CPU,
 you almost certainly do not.
 - There is not currently a way to execute `grabnode` with flags;
 you are required to use the interactive questions.
+- If you get an error like "Invalid Account" it indicates that your association to a PI account has not been completely set up- contact Scientific Computing.
 
 You'll note your command prompt will switch to say `gizmo` instead of `rhino`:
 

--- a/_scicomputing/access_credentials.md
+++ b/_scicomputing/access_credentials.md
@@ -14,6 +14,10 @@ If one of your collaborators requires access to the Fred Hutch network you can s
 
 Please see the Service Desk site on CenterNet for more information about [HutchNet ID](https://centernet.fredhutch.org/cn/u/center-it/help-desk.html) including password rotation, etc.
 
+## Accessing Slurm Clusters
+
+To use Slurm clusters (like _gizmo_ and _beagle_) you also need to have your HutchNet ID associated with a PI account.  Errors similar to "Invalid account or account/partition" typically indicate that this association hasn't been set up.  Contact Scientific Computing to have this corrected.
+
 ## GitHub.com
 
 The [Fred Hutch GitHub organization](https://github.com/FredHutch) offers free access to public and private git repositories to all Fred Hutch staff and collaborators. If you are a Fred Hutch employee working with source code and don't have a github.com account yet, please [create one](https://github.com/join) and email `scicomp`: "Please add my GitHub user id `xyz` to organization github.com/FredHutch". Once you are a member of the organization you can create repositories, teams and invite external collaborators to share and edit code.

--- a/_scicomputing/compute_platforms.md
+++ b/_scicomputing/compute_platforms.md
@@ -35,7 +35,7 @@ While we generally don't recommend interactive computing on the HPC clusters- in
 
 If you need an interactive session with dedicated resources, you can start a job on the cluster using the command `grabnode`.  The `grabnode` command will start an interactive login session on a cluster node.  This command will prompt you for how many cores, how much memory, and how much time is required
 
-This command can be run from any `rhino` host.
+This command can be run from any `rhino` host.  Access to the Gizmo cluster requires both a HutchNet ID and an association to a PI account on the cluster.  If you get errors like "Invalid account" when using `grabnode` or Slurm commands like `sbatch` then you will need to contact Scientific Computing to have that set up.
 
 ### NoMachine Access
 


### PR DESCRIPTION
A common problem for new users is that a missing association to a PI account raises an error which isn't terribly clear about the reason or solution.  This adds additional information to key pages for new users.