### PR TITLE
Changes to accommodate security review

### DIFF
--- a/_compdemos/motuz.md
+++ b/_compdemos/motuz.md
@@ -23,7 +23,7 @@ At this time, Motuz allows copying of files/objects between the following file s
 * [SFTP](https://en.wikipedia.org/wiki/SSH_File_Transfer_Protocol)
 * [WebDAV](https://en.wikipedia.org/wiki/WebDAV)
 * [Dropbox](https://www.dropbox.com/) (Beta)
-* [Microsoft OneDrive](https://onedrive.live.com/about/auth/) (Beta)
+* [Microsoft OneDrive](https://onedrive.live.com/about/auth/) (Beta, does not currently support FredHutch OneDrive for Business)
 
 This demo will focus on moving files between 
 shared file systems on campus and Amazon S3.

--- a/_generation/clsp_labCov.md
+++ b/_generation/clsp_labCov.md
@@ -36,7 +36,7 @@ The tools to capture laboratory covariates depend on the workflow needs.  Any ty
 LabArchives (Professional Edition) electronic lab notebook software is a secure, browser-based, and collaborative research-specific workflow tool that was designed for the storage, organization, sharing, and publishing of laboratory research and data for scientific research. You can create a free trial account at LabArchives to explore more.
 
 - Account creation for Non-Fred Hutch users: [Register Here](https://mynotebook.labarchives.com/sitesignup?stay=here)
-- Account creation for Fred Hutch users: [Register Here](https://mynotebook.labarchives.com/sitesignup?stay=here) Register using your Hutch ID (@fredhutch.org) email and you will be able to access your secure account through your MyHutch login. the registration will route you to access the application through your MyHutch page. For additional details on Fred Hutch ELN access, please refer to [additional documentation in CenterNet.](https://centernet.fredhutch.org/cn/u/center-it/projects/eln-project.html)
+- Account creation for Fred Hutch users: [Register Here](https://mynotebook.labarchives.com/sitesignup?stay=here) Register using your Hutch ID (@fredhutch.org) email and you will be able to access your secure account through your HutchNetID. the registration will route you to access the application through your My Apps page. For additional details on Fred Hutch ELN access, please refer to [additional documentation in CenterNet.](https://centernet.fredhutch.org/cn/u/center-it/projects/eln-project.html)
 
 
 ### LabMatrix

--- a/_generation/human_deidentification.md
+++ b/_generation/human_deidentification.md
@@ -4,6 +4,7 @@ last_modified_at: 2018-10-25
 main_authors: Susan Glick, Jason Major, Jennifer Kogut, Karen Hansen
 primary_reviewers: JasonMajor1, sgglick
 ---
+
 ## What is de-identification?
 
 De-identification refers to the removal or dissociation of direct patient
@@ -99,4 +100,4 @@ data type and degree of processing of the specific data entity. The inclusion of
 racial, ethnic and genders in scientific research however, can be a reason to
 retain some of these indirect identifiers in the context of research datasets.
 Thus, in addition, confidentiality is supported through strong use limitations,
-data use agreements and appropriate data security.
+data use agreements and appropriate data security. Concerns about the reliability and limitations of de-identification have increased interest in differential privacy and other alternative privacy-preserving techniques. 

--- a/_generation/human_overview.md
+++ b/_generation/human_overview.md
@@ -3,6 +3,8 @@ title: Overview of Data Privacy and Security
 last_modified_at: 2018-12-01
 ---
 
+FIXME: In some instances, sharing data may be possible without compromising the confidentiality of participants if privacy-preserving techniques have been properly applied, but if there are circumstances where data needs to be restricted due to the inability to protect confidentiality, this should be fully addressed in the data management and sharing plan. This section addresses various aspects of data privacy and security including data that originates from human subjects or specimens.
+
 This section contains a variety of types of information about relevant
 regulations and guidance for implementing studies using human subjects,
 human data and/or human specimens. Given the evolving conditions and rules

--- a/_generation/human_shareDeposits.md
+++ b/_generation/human_shareDeposits.md
@@ -5,6 +5,10 @@ main_authors: Susan Glick, Jason Major, Karen Hansen
 primary_reviewers: sgglick, JasonMajor1
 ---
 
+FIXME: Recommend adding new section, Data Sharing Security, after Data Sharing and Management Plans.
+While data sharing has many benefits and plays an increasingly critical in advancing research, it can also introduce a number of sometimes difficult to assess risks related to information security and privacy. The information security information available on CenterNet and can help you ensure data sharing arrangements are structured to minimize risk and generally comply with Fred Hutch Information Security Standards. Because data sharing methods are diverse and constantly evolving, it may be difficult to determine whether a specific data sharing plan or application is compliant and has sufficient protections in place. If you are planning to share data, you can request a security review from the Information Security Office (ISO) in CIT. In addition to helping you determine if the data sharing plan meets fulfills security requirements, ISO and CIT may also be able to assist you in implementing a reliable, high performance architecture that takes full advantage of such key features such as integration with Fred Hutch ID  and multifactor authentication (MFA). 
+
+
 Whether required for funding and publication or desired for its beneficial impact on research progress, understanding the why and how of data sharing is essential for modern biomedical research programs.
 
 ## Benefits of Data Sharing

--- a/_scicomputing/access_methods.md
+++ b/_scicomputing/access_methods.md
@@ -13,6 +13,8 @@ Using these desktop computing resources, the following describes how to access a
 
 ## SSH Clients for Remote Computing Resources
 
+FIXME: remove specific login info for ssh
+
 We use two common protocols to access remote compute resources. The first is the Hypertext Transfer Protocol (HTTP). This is the way your browser communicates with remote web servers. The second common protocol is Secure SHell (SSH). This is the method used to run a program on a remote server. Typically the program run is a `shell` that gives you an interactive command line on the remote host.
 
 Many programs you will want to run on a remote compute server are command line programs. These are easily executed from your `shell` remote process. You use this method when opening a terminal (`shell`) on your computer to connect to a remote compute server (like `rhino`) and typing the name of the program or script.

--- a/_scicomputing/access_methods.md
+++ b/_scicomputing/access_methods.md
@@ -15,6 +15,12 @@ Using these desktop computing resources, the following describes how to access a
 
 FIXME: remove specific login info for ssh
 
+DESCRIPTION: The section “Access via a Remote Location” overlaps with CenterNet pages on VPN (https://CenterNet.fredhutch.org/cn/u/center-it/help-desk/vpn.html) and RDS (https://CenterNet.fredhutch.org/cn/u/center-it/services/rds.html).  
+
+CHANGES: Recommend expanding CenterNet content to cover Snail and new SFTP service and revising the SciWiki content to a summary and link to CenterNet content:
+CenterNet has information on remote data access methods available at Fred Hutch, including VPN, RDS, and SSH/SFTP gateways. By storing data in Office 365 or other Fred Hutch-approved cloud-based systems, you can avoid having to use one of these remote network gateways to access data securely. You may contact ISO if you have security-related questions about storing or accessing data in the cloud.
+
+
 We use two common protocols to access remote compute resources. The first is the Hypertext Transfer Protocol (HTTP). This is the way your browser communicates with remote web servers. The second common protocol is Secure SHell (SSH). This is the method used to run a program on a remote server. Typically the program run is a `shell` that gives you an interactive command line on the remote host.
 
 Many programs you will want to run on a remote compute server are command line programs. These are easily executed from your `shell` remote process. You use this method when opening a terminal (`shell`) on your computer to connect to a remote compute server (like `rhino`) and typing the name of the program or script.

--- a/_scicomputing/store_collaboration.md
+++ b/_scicomputing/store_collaboration.md
@@ -4,6 +4,12 @@ last_modified_at: 2019-04-01
 primary_reviewers: vortexing
 ---
 
+FIXME
+
+DESCRIPTION: This content overlaps with Collaboration Tools content on CenterNet (https://CenterNet.fredhutch.org/cn/u/center-it/collaboration-tools.html, Recommend revising the SciWiki content to a summary and link to CenterNet content:
+CHANGES: CenterNet has information on data storage collaboration tools available at Fred Hutch. These include the Office 365 platform, which integrates Email, Teams, OneDrive, and SharePoint, is HIPAA-compliant, and provides strong authentication and end-to-end data encryption. 
+
+
 There are Fred Hutch supported data storage systems that allow you to share data with people outside the Hutch, with or without a Hutch ID in order to facilitate data transfer and receipt in collaborations within or outside of the Fred Hutch.  
 
 ## Aspera

--- a/_scicomputing/store_posix.md
+++ b/_scicomputing/store_posix.md
@@ -3,6 +3,12 @@ title: Data Storage in File Storage Systems
 primary_reviewer: dirkpetersen
 ---
 
+FIXME: Moving pointers to dfs server to centernet
+
+DESCRIPTION: This content overlaps with content in Data Storage and Protection page on CenterNet (https://CenterNet.fredhutch.org/cn/u/center-it/services/storedataprotect.html). Recommend revising the SciWiki content to a summary and link to updated and expanded CenterNet section:
+
+CHANGES: CenterNet has current information on data storage systems, including file, block, and object storage, available at Fred Hutch. Some key considerations in selecting the appropriate data storage system for a project include performance, cost, data encryption and other security requirements, and compatibility with various data access tools and analysis methods. 
+
 File keeps your data on disks and allows access to your data using familiar tools you're used to: Unix commands like `cat`, `cp`, `ls`, and `rm`,  browser tools like Windows Explorer or OSX's Finder (to browse drives mapped to your local workstation), and most common Bioinformatic tools.  These storage systems are similar to the hard drive on your computer, just typically larger and faster.
 
 There are multiple file storage resources available to researchers including:


### PR DESCRIPTION
I'm initially opening this PR as a placeholder to indicate which areas in the wiki will be updated as per ISO's security review. This will be made available for review/merge when appropriate information has been published in Centernet. Relevant changes are summarized as follows:

- Moving for SSH based remote login content from here https://sciwiki.fredhutch.org/scicomputing/access_methods/  to Centernet
- Moving pointers to dfs server from https://sciwiki.fredhutch.org/scicomputing/store_posix/ to Centernet
- Adding information for better partnering with ISO to parts in the wiki
- Some non-security related content improvements