### PR TITLE
Mrg/gizmo sched

### DIFF
--- a/_scicomputing/compute_accounts.md
+++ b/_scicomputing/compute_accounts.md
@@ -6,11 +6,11 @@ primary_reviewer: atombaby
 
 The compute resources provided by Scientific Computing are available to all Hutch researchers. As a shared resource in high demand, it's necessary to manage usage to ensure some measure of equitable access to all research.
 
-This is primarily seen in the Gizmo cluster, where we have both a) limits on how much can be used by individuals and groups and b) algorithms that prioritize pending work.  The limits and prioritization algorithms serve to schedule the waiting jobs for available resources.
+This high demand for a shared resource is primarily seen in the Gizmo cluster, where we have both a) limits on how much can be used by individuals and groups and b) algorithms that prioritize pending work.  The limits and prioritization algorithms serve to schedule the waiting jobs for available resources.
 
-The _cluster account_ is the basis for these algorithms- the calculation of a job's priority for scheduling purposes and the entity on which limits are placed.
+The _cluster account_ is the basis for these algorithms - the calculation of a job's priority for scheduling purposes and the entity on which limits are placed.
 
-Thus, the cluster account only provides access to the cluster. After creating the account, individuals are associated with the account which allows that user to submit jobs into that account.
+Thus, the cluster account only provides access to the cluster. After creating the account, individuals are associated with the account, allowing them to submit jobs into that account.
 
 Cluster accounts are created for Hutch faculty and NIH grant principals. Associations to accounts are created manually, either on request from a faculty or designate or by user request when the individual is indicated as a report to faculty in Workday.
 

--- a/_scicomputing/compute_accounts.md
+++ b/_scicomputing/compute_accounts.md
@@ -1,59 +1,21 @@
 ---
-title: Cluster Accounts and Usage Limits
+title: Cluster Accounts
 last_modified_at: 2021-02-09
 primary_reviewer: atombaby
 ---
 
-The compute resources provided by Scientific Computing are available to all Hutch researchers.  As a shared resource in high demand, it's necessary to manage usage such that some resources are available on short notice.
+The compute resources provided by Scientific Computing are available to all Hutch researchers.  As a shared resource in high demand, it's necessary to manage usage to ensure some measure of equitable access to all research.
 
-This is primarily seen in the Gizmo cluster, where we have limits on how much can be used by individuals and groups and algorithms that prioritize pending work.  The limits and prioritization algorithms serve to schedule the waiting jobs for available resources.
+This is primarily seen in the Gizmo cluster, where we have both a) limits on how much can be used by individuals and groups and b) algorithms that prioritize pending work.  The limits and prioritization algorithms serve to schedule the waiting jobs for available resources.
 
-A primary goal of this process of job scheduling is to ensure sufficient idle resources for "new work" to start quickly ("new work" meaining jobs from cluster accounts that don't already have active jobs).  The other scheduling goal is the equitable allocation of resources, that each group has access to the same amount of resources.
+The _cluster account_ is the basis for these algorithms- the calculation of a job's priority for scheduling purposes and the entity on which limits are placed.
 
-To this end, each group is limited to a maximum amount of computational resources- no one group can dominate the resources- currently this is implemented as a maximum on the number of cores available.  Furthermore, as a group's usage increases, the priority of that group's waiting jobs is lowered, allowing other groups to access idle resources.  This "fairshare" algorithm looks at usage over 24 hours and adds priority to a group's jobs if that group hasn't been using the group's "fair share" of the cluster.
+Thus, the cluster account only provides access to the cluster.  After creating the account, individuals are associated with the account which allows that user to submit jobs into that account.
 
-### A Metaphor
+Cluster accounts are created for Hutch faculty and NIH grant principals.Associations to accounts are created manually, eithe on request from faculty or designate or by user request when the individual is indicated as a report to faculty in Workday.
 
-Imagine a fenced pasture for grazing.  Around this pasture are many farmers, each with a gate to the field.  Some farmers raise cattle, some sheep, and other chickens.  Each animal has different needs and requires a different amount of space in the pasture.  For example, cows need a big chunk of that pasture- sheep require less, and chickens less than sheep.
+## Account Versus Allocation
 
-All of these farmers have different needs- some don't raise a lot of livestock and can get by in a pen inside their farm.  Others raise vegetables.  Some have huge herds and flocks and are dependent on ready access to the pasture.
+The terms "account" and "allocation" are often conflated in conversations about usage limits.  However, it is important to note that we do not "allocate" resources to individuals or accounts in the sense of reserving or designating resources for an account's use.
 
-Fitting all of that onto the pasture becomes the problem.  When farmers don't have a lot of animals this is a fairly easy problem  As the population of livestock increases, timely access to sufficient pasture becomes a problem.
-
-If farmers' gates were open all the time it would be a proper mess, so the farmers agree to limit the amount of pasture any one farmer can use at any time.
-
-Access to the pasture is exclusively through one of the existing farmers' gates- so any farmhands who want to graze need to work through one of those farmers with a gate.
-
-## Cluster Accounts
-
-The _cluster account_ provides access to the cluster.  No one is able to submit jobs to the cluster without being associated to a cluster account.  The account provides the primary basis for measuring usage and enforcing limits.
-
-Accounts are created for Hutch Faculty and NIH grant principals.
-
-### A Metaphor
-
-In the metaphor of the farmer's pasture, the account is the gate from the farmer's property to the pasture. 
-
-## Limits and Allocations
-
-Accounts do not provide a guarantee of an explicit number of cores at any time- resources are not set aside (allocated) for any one account but are in a general pool. This oversubsription allows us to have higher limits than an explicit, dedicated per-account allocation.
-
-Large numbers of cores will only becore available over time- only the first few cores are instantaneously available.
-
-### A Metaphor
-
-Access to the pasture doesn't mean that the farmer has a section reserved for their animals or that they will be able to put all of their livestock out at the same time. If the pasture is very full, one or two head will have space to run, but it will be some time before all of the farmer's livestock can be put to pasture.
-
-## Scheduling: Fairshare and Backfill
-
-Pending jobs are assigned a priority- jobs with higher priority are run before lower priority jobs.  This priority is primarily calculated using the "fairshare algorithm" which looks at the usage by an account over a period of time.  Older usage is decayed using something like a half-life calculation so that current usage has the greater impact on the job's priority.
-
-There is an additional time factor which accounts for the amount of time a job has been waiting.  This and the fairshare factor are combined to calculate the job's priority- multipliers provide different weights to those factors.  The wait-time for a job has a very small factor and only ensures basic ordering of jobs for an account.
-
-The jobs with the highest priority are reserved resources- the scheduler identifies suitable resources which are or will be available and reserves those for the job.
-
-However, there is another mechanism for jobs to get resources.  Once those reservations are made, jobs which can fit onto idle resources and don't block those reservations can be allocated those resources.  This "backfill" mechanism allows lower priority jobs to run on otherwise unused nodes.
-
-### A Metaphor
-
-When the pasture is filling up it becomes necessary for the farmers to have more care in putting livestock into the field.  To do this, farmers who have had a lot of livestock grazing hold back putting more livestock out to allow those who have not been grazing to put out their herd.
+These systems are managed as a common pool with systems designed to provide a minimum of resources "instantaneously" to an account with larger volumes of computational resources available to that account over time.

--- a/_scicomputing/compute_accounts.md
+++ b/_scicomputing/compute_accounts.md
@@ -4,15 +4,15 @@ last_modified_at: 2021-02-09
 primary_reviewer: atombaby
 ---
 
-The compute resources provided by Scientific Computing are available to all Hutch researchers.  As a shared resource in high demand, it's necessary to manage usage to ensure some measure of equitable access to all research.
+The compute resources provided by Scientific Computing are available to all Hutch researchers. As a shared resource in high demand, it's necessary to manage usage to ensure some measure of equitable access to all research.
 
 This is primarily seen in the Gizmo cluster, where we have both a) limits on how much can be used by individuals and groups and b) algorithms that prioritize pending work.  The limits and prioritization algorithms serve to schedule the waiting jobs for available resources.
 
 The _cluster account_ is the basis for these algorithms- the calculation of a job's priority for scheduling purposes and the entity on which limits are placed.
 
-Thus, the cluster account only provides access to the cluster.  After creating the account, individuals are associated with the account which allows that user to submit jobs into that account.
+Thus, the cluster account only provides access to the cluster. After creating the account, individuals are associated with the account which allows that user to submit jobs into that account.
 
-Cluster accounts are created for Hutch faculty and NIH grant principals.Associations to accounts are created manually, eithe on request from faculty or designate or by user request when the individual is indicated as a report to faculty in Workday.
+Cluster accounts are created for Hutch faculty and NIH grant principals. Associations to accounts are created manually, either on request from a faculty or designate or by user request when the individual is indicated as a report to faculty in Workday.
 
 ## Account Versus Allocation
 

--- a/_scicomputing/compute_accounts.md
+++ b/_scicomputing/compute_accounts.md
@@ -1,0 +1,59 @@
+---
+title: Cluster Accounts and Usage Limits
+last_modified_at: 2021-02-09
+primary_reviewer: atombaby
+---
+
+The compute resources provided by Scientific Computing are available to all Hutch researchers.  As a shared resource in high demand, it's necessary to manage usage such that some resources are available on short notice.
+
+This is primarily seen in the Gizmo cluster, where we have limits on how much can be used by individuals and groups and algorithms that prioritize pending work.  The limits and prioritization algorithms serve to schedule the waiting jobs for available resources.
+
+A primary goal of this process of job scheduling is to ensure sufficient idle resources for "new work" to start quickly ("new work" meaining jobs from cluster accounts that don't already have active jobs).  The other scheduling goal is the equitable allocation of resources, that each group has access to the same amount of resources.
+
+To this end, each group is limited to a maximum amount of computational resources- no one group can dominate the resources- currently this is implemented as a maximum on the number of cores available.  Furthermore, as a group's usage increases, the priority of that group's waiting jobs is lowered, allowing other groups to access idle resources.  This "fairshare" algorithm looks at usage over 24 hours and adds priority to a group's jobs if that group hasn't been using the group's "fair share" of the cluster.
+
+### A Metaphor
+
+Imagine a fenced pasture for grazing.  Around this pasture are many farmers, each with a gate to the field.  Some farmers raise cattle, some sheep, and other chickens.  Each animal has different needs and requires a different amount of space in the pasture.  For example, cows need a big chunk of that pasture- sheep require less, and chickens less than sheep.
+
+All of these farmers have different needs- some don't raise a lot of livestock and can get by in a pen inside their farm.  Others raise vegetables.  Some have huge herds and flocks and are dependent on ready access to the pasture.
+
+Fitting all of that onto the pasture becomes the problem.  When farmers don't have a lot of animals this is a fairly easy problem  As the population of livestock increases, timely access to sufficient pasture becomes a problem.
+
+If farmers' gates were open all the time it would be a proper mess, so the farmers agree to limit the amount of pasture any one farmer can use at any time.
+
+Access to the pasture is exclusively through one of the existing farmers' gates- so any farmhands who want to graze need to work through one of those farmers with a gate.
+
+## Cluster Accounts
+
+The _cluster account_ provides access to the cluster.  No one is able to submit jobs to the cluster without being associated to a cluster account.  The account provides the primary basis for measuring usage and enforcing limits.
+
+Accounts are created for Hutch Faculty and NIH grant principals.
+
+### A Metaphor
+
+In the metaphor of the farmer's pasture, the account is the gate from the farmer's property to the pasture. 
+
+## Limits and Allocations
+
+Accounts do not provide a guarantee of an explicit number of cores at any time- resources are not set aside (allocated) for any one account but are in a general pool. This oversubsription allows us to have higher limits than an explicit, dedicated per-account allocation.
+
+Large numbers of cores will only becore available over time- only the first few cores are instantaneously available.
+
+### A Metaphor
+
+Access to the pasture doesn't mean that the farmer has a section reserved for their animals or that they will be able to put all of their livestock out at the same time. If the pasture is very full, one or two head will have space to run, but it will be some time before all of the farmer's livestock can be put to pasture.
+
+## Scheduling: Fairshare and Backfill
+
+Pending jobs are assigned a priority- jobs with higher priority are run before lower priority jobs.  This priority is primarily calculated using the "fairshare algorithm" which looks at the usage by an account over a period of time.  Older usage is decayed using something like a half-life calculation so that current usage has the greater impact on the job's priority.
+
+There is an additional time factor which accounts for the amount of time a job has been waiting.  This and the fairshare factor are combined to calculate the job's priority- multipliers provide different weights to those factors.  The wait-time for a job has a very small factor and only ensures basic ordering of jobs for an account.
+
+The jobs with the highest priority are reserved resources- the scheduler identifies suitable resources which are or will be available and reserves those for the job.
+
+However, there is another mechanism for jobs to get resources.  Once those reservations are made, jobs which can fit onto idle resources and don't block those reservations can be allocated those resources.  This "backfill" mechanism allows lower priority jobs to run on otherwise unused nodes.
+
+### A Metaphor
+
+When the pasture is filling up it becomes necessary for the farmers to have more care in putting livestock into the field.  To do this, farmers who have had a lot of livestock grazing hold back putting more livestock out to allow those who have not been grazing to put out their herd.

--- a/_scicomputing/compute_job_scheduling.md
+++ b/_scicomputing/compute_job_scheduling.md
@@ -32,7 +32,9 @@ Pending jobs are assigned a priority- jobs with higher priority are run before l
 
 There is an additional time factor which accounts for the amount of time a job has been waiting.  This and the fairshare factor are combined to calculate the job's priority- multipliers provide different weights to those factors.  The wait-time for a job has a very small factor and only ensures basic ordering of jobs for an account.
 
-The jobs with the highest priority are reserved resources- the scheduler identifies suitable resources which are or will be available and reserves those for the job.
+The jobs with the highest priority are allocated resources if available.  If there are no suitable resources idle, then the scheduler will identify appropriate resources and reserve those for the job.  This is done for a few of the highest priority jobs.
 
-However, there is another mechanism for jobs to get resources.  Once those reservations are made, jobs which can fit onto idle resources and don't block those reservations can be allocated those resources.  This "backfill" mechanism allows lower priority jobs to run on otherwise unused nodes.
+There is another mechanism for jobs to get resources.  Jobs which can fit onto idle resources and don't block other jobs can be allocated idle resources.  This "backfill" mechanism allows lower priority jobs to run on otherwise unused nodes.
+
+For example, if there is one idle core and two pending jobs, the higher priority job will get that core.  However, if that higher priority job requires four cores, the lower job may be run if it will complete before the other three cores become available.
 

--- a/_scicomputing/compute_job_scheduling.md
+++ b/_scicomputing/compute_job_scheduling.md
@@ -12,43 +12,23 @@ A primary goal of this process of job scheduling is to ensure sufficient idle re
 
 To this end, each group is limited to a maximum amount of computational resources- no one group can use all of the resources. Currently this is implemented as a maximum on the number of cores available.  Furthermore, as a group's usage increases, the priority of that group's waiting jobs is lowered, allowing other groups to access idle resources.  This "fairshare" algorithm looks at usage over 24 hours and adds priority to a group's jobs if that group hasn't been using the group's "fair share" of the cluster.
 
-### A Metaphor
-
-Imagine a fenced pasture for grazing.  Around this pasture are many farmers, each with a gate to the field.  Some farmers raise cattle, some sheep, and other chickens.  Each animal has different needs and requires a different amount of space in the pasture.  For example, cows need a big chunk of that pasture- sheep require less, and chickens less than sheep.
-
-All of these farmers have different needs- some don't raise a lot of livestock and can get by in a pen inside their farm.  Others raise vegetables.  Some have huge herds and flocks and are dependent on ready access to the pasture.
-
-Fitting all of that onto the pasture becomes the problem.  When farmers don't have a lot of animals this is a fairly easy problem  As the population of livestock increases, timely access to sufficient pasture becomes a problem.
-
-If farmers' gates were open all the time it would be a proper mess, so the farmers agree to limit the amount of pasture any one farmer can use at any time.
-
-Access to the pasture is exclusively through one of the existing farmers' gates- so any farmhands who want to graze need to work through one of those farmers with a gate.
-
 ## Cluster Accounts
 
-The [[cluster account|scicomputing/compute_accounts]] provides access to the cluster.  No one is able to submit jobs to the cluster without being associated to a cluster account.  The account provides the primary basis for measuring usage and enforcing limits.
+The cluster account provides access to the cluster.  No one is able to submit jobs to the cluster without being associated to a cluster account.  The account provides the primary basis for measuring usage and enforcing limits. More information about accounts is available [[here|scicomputing/compute_accounts]] 
 
-Accounts are created for Hutch Faculty and NIH grant principals.
+## Limits
 
-### A Metaphor
+> It is important to note that we do not allocate any particular resource or set of resources for accounts.  The resources in the cluster are generally available until allocated to a job.
 
-In the metaphor of the farmer's pasture, the account is the gate from the farmer's property to the pasture. 
+Limits on resource usage are the primary tool used to ensure that we maintain some idle resources to allow for instantaneous demand from accounts which do not have active work.  When an account has reached this limit, pending jobs are blocked from running until the number of cores in use by this account fall below the limit.
 
-## Limits and Allocations
+While resources are not explicitly allocated to a group, we do have a goal of providing 300 cores per account.  However, that number of cores may only become available over time- only the first few cores are instantaneously available.
 
-An account does not provide a guarantee of an explicit number of cores at any time- resources are not set aside (allocated) for any one account but are in a general pool. This oversubsription allows us to have higher limits than an explicit, dedicated per-account allocation.
-
-Large numbers of cores will only becore available over time- only the first few cores are instantaneously available.
-
-Limits do change over time.  There is a process that monitors available resources and adjusts limits up and down depending on the amount of idle resources.
-
-### A Metaphor
-
-Access to the pasture doesn't mean that the farmer has a section reserved for their animals or that they will be able to put all of their livestock out at the same time. If the pasture is very full, one or two head will have space to run, but it will be some time before all of the farmer's livestock can be put to pasture.
+The goal is a minimum target.  To improve utilization, there is a process that monitors available resources and adjusts limits up and down depending on the amount of idle resources.  These limits are tracked and times when the limit is below the goal are note in that monitoring system.
 
 ## Scheduling: Fairshare and Backfill
 
-Pending jobs are assigned a priority- jobs with higher priority are run before lower priority jobs.  This priority is primarily calculated using the "fairshare algorithm" which looks at the usage by an account over a period of time.  Older usage is decayed using something like a half-life calculation so that current usage has the greater impact on the job's priority.
+Pending jobs are assigned a priority- jobs with higher priority are run before lower priority jobs.  This priority is primarily calculated using the "fairshare algorithm" which looks at the usage by an account over a period of time.  Older usage is decayed using something like a half-life calculation so that an account's current usage has the greater impact on the job's priority.
 
 There is an additional time factor which accounts for the amount of time a job has been waiting.  This and the fairshare factor are combined to calculate the job's priority- multipliers provide different weights to those factors.  The wait-time for a job has a very small factor and only ensures basic ordering of jobs for an account.
 
@@ -56,6 +36,3 @@ The jobs with the highest priority are reserved resources- the scheduler identif
 
 However, there is another mechanism for jobs to get resources.  Once those reservations are made, jobs which can fit onto idle resources and don't block those reservations can be allocated those resources.  This "backfill" mechanism allows lower priority jobs to run on otherwise unused nodes.
 
-### A Metaphor
-
-When the pasture is filling up it becomes necessary for the farmers to have more care in putting livestock into the field.  To do this, farmers who have had a lot of livestock grazing hold back putting more livestock out to allow those who have not been grazing to put out their herd.

--- a/_scicomputing/compute_job_scheduling.md
+++ b/_scicomputing/compute_job_scheduling.md
@@ -26,7 +26,7 @@ Access to the pasture is exclusively through one of the existing farmers' gates-
 
 ## Cluster Accounts
 
-The _cluster account_ provides access to the cluster.  No one is able to submit jobs to the cluster without being associated to a cluster account.  The account provides the primary basis for measuring usage and enforcing limits.
+The [[cluster account|scicomputing/compute_accounts]] provides access to the cluster.  No one is able to submit jobs to the cluster without being associated to a cluster account.  The account provides the primary basis for measuring usage and enforcing limits.
 
 Accounts are created for Hutch Faculty and NIH grant principals.
 
@@ -36,7 +36,7 @@ In the metaphor of the farmer's pasture, the account is the gate from the farmer
 
 ## Limits and Allocations
 
-Accounts do not provide a guarantee of an explicit number of cores at any time- resources are not set aside (allocated) for any one account but are in a general pool. This oversubsription allows us to have higher limits than an explicit, dedicated per-account allocation.
+An account does not provide a guarantee of an explicit number of cores at any time- resources are not set aside (allocated) for any one account but are in a general pool. This oversubsription allows us to have higher limits than an explicit, dedicated per-account allocation.
 
 Large numbers of cores will only becore available over time- only the first few cores are instantaneously available.
 

--- a/_scicomputing/compute_job_scheduling.md
+++ b/_scicomputing/compute_job_scheduling.md
@@ -1,5 +1,5 @@
 ---
-title: Cluster Accounts and Usage Limits
+title: Gizmo Job Scheduling
 last_modified_at: 2021-02-09
 primary_reviewer: atombaby
 ---
@@ -10,7 +10,7 @@ This is primarily seen in the Gizmo cluster, where we have limits on how much ca
 
 A primary goal of this process of job scheduling is to ensure sufficient idle resources for "new work" to start quickly ("new work" meaining jobs from cluster accounts that don't already have active jobs).  The other scheduling goal is the equitable allocation of resources, that each group has access to the same amount of resources.
 
-To this end, each group is limited to a maximum amount of computational resources- no one group can dominate the resources- currently this is implemented as a maximum on the number of cores available.  Furthermore, as a group's usage increases, the priority of that group's waiting jobs is lowered, allowing other groups to access idle resources.  This "fairshare" algorithm looks at usage over 24 hours and adds priority to a group's jobs if that group hasn't been using the group's "fair share" of the cluster.
+To this end, each group is limited to a maximum amount of computational resources- no one group can use all of the resources. Currently this is implemented as a maximum on the number of cores available.  Furthermore, as a group's usage increases, the priority of that group's waiting jobs is lowered, allowing other groups to access idle resources.  This "fairshare" algorithm looks at usage over 24 hours and adds priority to a group's jobs if that group hasn't been using the group's "fair share" of the cluster.
 
 ### A Metaphor
 
@@ -39,6 +39,8 @@ In the metaphor of the farmer's pasture, the account is the gate from the farmer
 An account does not provide a guarantee of an explicit number of cores at any time- resources are not set aside (allocated) for any one account but are in a general pool. This oversubsription allows us to have higher limits than an explicit, dedicated per-account allocation.
 
 Large numbers of cores will only becore available over time- only the first few cores are instantaneously available.
+
+Limits do change over time.  There is a process that monitors available resources and adjusts limits up and down depending on the amount of idle resources.
 
 ### A Metaphor
 

--- a/_scicomputing/compute_job_scheduling.md
+++ b/_scicomputing/compute_job_scheduling.md
@@ -4,37 +4,37 @@ last_modified_at: 2021-02-09
 primary_reviewer: atombaby
 ---
 
-The compute resources provided by Scientific Computing are available to all Hutch researchers.  As a shared resource in high demand, it's necessary to manage usage such that some resources are available on short notice.
+The compute resources provided by Scientific Computing are available to all Hutch researchers. As a shared resource in high demand, it's necessary to manage usage such that some resources are available on short notice.
 
-This is primarily seen in the Gizmo cluster, where we have limits on how much can be used by individuals and groups and algorithms that prioritize pending work.  The limits and prioritization algorithms serve to schedule the waiting jobs for available resources.
+This is primarily seen in the Gizmo cluster, where we have limits on resource use by individuals and groups and algorithms that prioritize pending work. The limits and prioritization algorithms serve to schedule the waiting jobs for available resources.
 
-A primary goal of this process of job scheduling is to ensure sufficient idle resources for "new work" to start quickly ("new work" meaining jobs from cluster accounts that don't already have active jobs).  The other scheduling goal is the equitable allocation of resources, that each group has access to the same amount of resources.
+A primary goal of this process of job scheduling is to ensure sufficient idle resources for "new work" to start quickly ("new work" meaining jobs from cluster accounts that don't already have active jobs). The other scheduling goal is the equitable allocation of resources, that each group has access to the same amount of resources.
 
-To this end, each group is limited to a maximum amount of computational resources- no one group can use all of the resources. Currently this is implemented as a maximum on the number of cores available.  Furthermore, as a group's usage increases, the priority of that group's waiting jobs is lowered, allowing other groups to access idle resources.  This "fairshare" algorithm looks at usage over 24 hours and adds priority to a group's jobs if that group hasn't been using the group's "fair share" of the cluster.
+To this end, each group is limited to a maximum amount of computational resources - no one group can use all of the resources. Currently this is implemented as a maximum on the number of cores available.  Furthermore, as a group's usage increases, the priority of that group's waiting jobs is lowered, allowing other groups to access idle resources.  This "fairshare" algorithm looks at usage over 24 hours and adds priority to a group's jobs if that group hasn't been using their "fair share" of the cluster.
 
 ## Cluster Accounts
 
-The cluster account provides access to the cluster.  No one is able to submit jobs to the cluster without being associated to a cluster account.  The account provides the primary basis for measuring usage and enforcing limits. More information about accounts is available [[here|scicomputing/compute_accounts]] 
+The cluster account provides access to the cluster. No one is able to submit jobs to the cluster without being associated to a cluster account. The account provides the primary basis for measuring usage and enforcing limits. More information about accounts is available [[here|scicomputing/compute_accounts]] 
 
 ## Limits
 
-> It is important to note that we do not allocate any particular resource or set of resources for accounts.  The resources in the cluster are generally available until allocated to a job.
+> It is important to note that we do not allocate or reserve any particular resource or set of resources for accounts.  The resources in the cluster are generally available until allocated to a job.
 
-Limits on resource usage are the primary tool used to ensure that we maintain some idle resources to allow for instantaneous demand from accounts which do not have active work.  When an account has reached this limit, pending jobs are blocked from running until the number of cores in use by this account fall below the limit.
+Limits on resource usage are the primary tool used to ensure that we maintain some idle resources to allow for instantaneous demand from accounts which do not have active work. When an account has reached this limit, pending jobs are blocked from running until the number of cores in use by this account fall below the limit.
 
-While resources are not explicitly allocated to a group, we do have a goal of providing 300 cores per account.  However, that number of cores may only become available over time- only the first few cores are instantaneously available.
+While resources are not explicitly allocated to a group, we do have a goal of providing a certain number cores per account (currently 300). However, that number of cores may only become available over time - only the first few cores are instantaneously available.
 
-The goal is a minimum target.  To improve utilization, there is a process that monitors available resources and adjusts limits up and down depending on the amount of idle resources.  These limits are tracked and times when the limit is below the goal are note in that monitoring system.
+The goal is a minimum target. To improve utilization, there is a process that monitors available resources and adjusts limits up and down depending on the amount of idle resources. These limits are tracked and times when the limit is below the goal are note in that monitoring system.
 
 ## Scheduling: Fairshare and Backfill
 
-Pending jobs are assigned a priority- jobs with higher priority are run before lower priority jobs.  This priority is primarily calculated using the "fairshare algorithm" which looks at the usage by an account over a period of time.  Older usage is decayed using something like a half-life calculation so that an account's current usage has the greater impact on the job's priority.
+Pending jobs are assigned a priority - jobs with higher priority are run before lower priority jobs. This priority is primarily calculated using the "fairshare" algorithm which looks at the usage by an account over a period of time. Older usage is decayed using something like a half-life calculation so that an account's current usage has the greater impact on the job's priority.
 
-There is an additional time factor which accounts for the amount of time a job has been waiting.  This and the fairshare factor are combined to calculate the job's priority- multipliers provide different weights to those factors.  The wait-time for a job has a very small factor and only ensures basic ordering of jobs for an account.
+There is an additional time factor which accounts for the amount of time a job has been waiting. This and the "fairshare" factor are combined to calculate the job's priority - multipliers provide different weights to those factors. The wait-time for a job has a very small factor and only ensures basic ordering of jobs for an account.
 
-The jobs with the highest priority are allocated resources if available.  If there are no suitable resources idle, then the scheduler will identify appropriate resources and reserve those for the job.  This is done for a few of the highest priority jobs.
+The jobs with the highest priority are allocated resources if available. If there are no suitable resources idle, then the scheduler will identify appropriate resources and reserve those for the job. This is done for a few of the highest priority jobs.
 
-There is another mechanism for jobs to get resources.  Jobs which can fit onto idle resources and don't block other jobs can be allocated idle resources.  This "backfill" mechanism allows lower priority jobs to run on otherwise unused nodes.
+There is another mechanism for jobs to get resources. Jobs which can fit onto idle resources and don't block other jobs can be allocated idle resources. This "backfill" mechanism allows lower priority jobs to run on otherwise unused nodes.
 
-For example, if there is one idle core and two pending jobs, the higher priority job will get that core.  However, if that higher priority job requires four cores, the lower job may be run if it will complete before the other three cores become available.
+For example, if there is one idle core and two pending jobs, the higher priority job will get that core. However, if that higher priority job requires four cores, the lower job may be run if it will complete before the other three cores become available.
 

--- a/_scicomputing/compute_job_scheduling.md
+++ b/_scicomputing/compute_job_scheduling.md
@@ -6,35 +6,35 @@ primary_reviewer: atombaby
 
 The compute resources provided by Scientific Computing are available to all Hutch researchers. As a shared resource in high demand, it's necessary to manage usage such that some resources are available on short notice.
 
-This is primarily seen in the Gizmo cluster, where we have limits on resource use by individuals and groups and algorithms that prioritize pending work. The limits and prioritization algorithms serve to schedule the waiting jobs for available resources.
+This high demand for a shared resource is primarily seen in the Gizmo cluster, where we have limits on resource use by individuals and groups and algorithms that prioritize pending work. The limits and prioritization algorithms serve to schedule the waiting jobs for available resources.
 
-A primary goal of this process of job scheduling is to ensure sufficient idle resources for "new work" to start quickly ("new work" meaining jobs from cluster accounts that don't already have active jobs). The other scheduling goal is the equitable allocation of resources, that each group has access to the same amount of resources.
+A primary goal of this process of job scheduling is to ensure sufficient idle resources for "new work" to start quickly ("new work" meaning jobs from cluster accounts that don't already have active jobs). The other scheduling goal is the equitable allocation of resources that each group has access to the same amount of resources.
 
-To this end, each group is limited to a maximum amount of computational resources - no one group can use all of the resources. Currently this is implemented as a maximum on the number of cores available.  Furthermore, as a group's usage increases, the priority of that group's waiting jobs is lowered, allowing other groups to access idle resources.  This "fairshare" algorithm looks at usage over 24 hours and adds priority to a group's jobs if that group hasn't been using their "fair share" of the cluster.
+To this end, each group is limited to a maximum amount of computational resources - no one group can use all the resources. Currently, this is implemented as a maximum on the number of cores available.  Furthermore, as a group's usage increases, the priority of that group's waiting jobs is lowered, allowing other groups to access idle resources.  This "fairshare" algorithm looks at usage over 24 hours and adds priority to a group's jobs if that group hasn't been using their "fair share" of the cluster.
 
 ## Cluster Accounts
 
-The cluster account provides access to the cluster. No one is able to submit jobs to the cluster without being associated to a cluster account. The account provides the primary basis for measuring usage and enforcing limits. More information about accounts is available [[here|scicomputing/compute_accounts]] 
+The cluster account provides access to the cluster. No one can submit jobs to the cluster without being associated with a cluster account. The account provides the primary basis for measuring usage and enforcing limits. More information about accounts is available [[here|scicomputing/compute_accounts]] 
 
 ## Limits
 
 > It is important to note that we do not allocate or reserve any particular resource or set of resources for accounts.  The resources in the cluster are generally available until allocated to a job.
 
-Limits on resource usage are the primary tool used to ensure that we maintain some idle resources to allow for instantaneous demand from accounts which do not have active work. When an account has reached this limit, pending jobs are blocked from running until the number of cores in use by this account fall below the limit.
+Limits on resource usage are the primary tool used to ensure that we maintain some idle resources to allow  instantaneous demand from accounts that do not have active work. When an account has reached this limit, pending jobs are blocked from running until the number of cores in use by this account fall below the limit.
 
-While resources are not explicitly allocated to a group, we do have a goal of providing a certain number cores per account (currently 300). However, that number of cores may only become available over time - only the first few cores are instantaneously available.
+While resources are not explicitly allocated to a group, we do have a goal of providing a certain number of cores per account (currently 300). However, that number of cores may only become available over time - only the first few cores are instantaneously available.
 
-The goal is a minimum target. To improve utilization, there is a process that monitors available resources and adjusts limits up and down depending on the amount of idle resources. These limits are tracked and times when the limit is below the goal are note in that monitoring system.
+The goal is a minimum target. There is a process that monitors available resources and adjusts limits up and down depending on the number of idle resources to improve utilization. These limits are tracked, and times when the limit is below the goal are noted in that monitoring system.
 
 ## Scheduling: Fairshare and Backfill
 
-Pending jobs are assigned a priority - jobs with higher priority are run before lower priority jobs. This priority is primarily calculated using the "fairshare" algorithm which looks at the usage by an account over a period of time. Older usage is decayed using something like a half-life calculation so that an account's current usage has the greater impact on the job's priority.
+Pending jobs are assigned a priority - jobs with higher priority are run before lower priority jobs. This priority is primarily calculated using the "fairshare" algorithm that looks at the usage by an account over a period of time. Older usage is decayed using something like a half-life calculation so that an account's current usage has the more significant impact on the job's priority.
 
-There is an additional time factor which accounts for the amount of time a job has been waiting. This and the "fairshare" factor are combined to calculate the job's priority - multipliers provide different weights to those factors. The wait-time for a job has a very small factor and only ensures basic ordering of jobs for an account.
+There is an additional time factor that accounts for the amount of time a job has been waiting. This additional time factor and the "fairshare" factor are combined to calculate the job's priority - multipliers provide different weights to those factors. The wait-time for a job has a very small factor and only ensures the basic ordering of jobs for an account.
 
-The jobs with the highest priority are allocated resources if available. If there are no suitable resources idle, then the scheduler will identify appropriate resources and reserve those for the job. This is done for a few of the highest priority jobs.
+The jobs with the highest priority are allocated resources if available. If there are no suitable resources idle, then the scheduler will identify appropriate resources and reserve those for the job. This resource reservation is done for a few of the highest priority jobs.
 
-There is another mechanism for jobs to get resources. Jobs which can fit onto idle resources and don't block other jobs can be allocated idle resources. This "backfill" mechanism allows lower priority jobs to run on otherwise unused nodes.
+There is another mechanism for jobs to get resources. Jobs that can fit onto idle resources and don't block other jobs can be allocated idle resources. This "backfill" mechanism allows lower priority jobs to run on otherwise unused nodes.
 
 For example, if there is one idle core and two pending jobs, the higher priority job will get that core. However, if that higher priority job requires four cores, the lower job may be run if it will complete before the other three cores become available.
 

--- a/_scicomputing/compute_job_scheduling.md
+++ b/_scicomputing/compute_job_scheduling.md
@@ -1,0 +1,59 @@
+---
+title: Cluster Accounts and Usage Limits
+last_modified_at: 2021-02-09
+primary_reviewer: atombaby
+---
+
+The compute resources provided by Scientific Computing are available to all Hutch researchers.  As a shared resource in high demand, it's necessary to manage usage such that some resources are available on short notice.
+
+This is primarily seen in the Gizmo cluster, where we have limits on how much can be used by individuals and groups and algorithms that prioritize pending work.  The limits and prioritization algorithms serve to schedule the waiting jobs for available resources.
+
+A primary goal of this process of job scheduling is to ensure sufficient idle resources for "new work" to start quickly ("new work" meaining jobs from cluster accounts that don't already have active jobs).  The other scheduling goal is the equitable allocation of resources, that each group has access to the same amount of resources.
+
+To this end, each group is limited to a maximum amount of computational resources- no one group can dominate the resources- currently this is implemented as a maximum on the number of cores available.  Furthermore, as a group's usage increases, the priority of that group's waiting jobs is lowered, allowing other groups to access idle resources.  This "fairshare" algorithm looks at usage over 24 hours and adds priority to a group's jobs if that group hasn't been using the group's "fair share" of the cluster.
+
+### A Metaphor
+
+Imagine a fenced pasture for grazing.  Around this pasture are many farmers, each with a gate to the field.  Some farmers raise cattle, some sheep, and other chickens.  Each animal has different needs and requires a different amount of space in the pasture.  For example, cows need a big chunk of that pasture- sheep require less, and chickens less than sheep.
+
+All of these farmers have different needs- some don't raise a lot of livestock and can get by in a pen inside their farm.  Others raise vegetables.  Some have huge herds and flocks and are dependent on ready access to the pasture.
+
+Fitting all of that onto the pasture becomes the problem.  When farmers don't have a lot of animals this is a fairly easy problem  As the population of livestock increases, timely access to sufficient pasture becomes a problem.
+
+If farmers' gates were open all the time it would be a proper mess, so the farmers agree to limit the amount of pasture any one farmer can use at any time.
+
+Access to the pasture is exclusively through one of the existing farmers' gates- so any farmhands who want to graze need to work through one of those farmers with a gate.
+
+## Cluster Accounts
+
+The _cluster account_ provides access to the cluster.  No one is able to submit jobs to the cluster without being associated to a cluster account.  The account provides the primary basis for measuring usage and enforcing limits.
+
+Accounts are created for Hutch Faculty and NIH grant principals.
+
+### A Metaphor
+
+In the metaphor of the farmer's pasture, the account is the gate from the farmer's property to the pasture. 
+
+## Limits and Allocations
+
+Accounts do not provide a guarantee of an explicit number of cores at any time- resources are not set aside (allocated) for any one account but are in a general pool. This oversubsription allows us to have higher limits than an explicit, dedicated per-account allocation.
+
+Large numbers of cores will only becore available over time- only the first few cores are instantaneously available.
+
+### A Metaphor
+
+Access to the pasture doesn't mean that the farmer has a section reserved for their animals or that they will be able to put all of their livestock out at the same time. If the pasture is very full, one or two head will have space to run, but it will be some time before all of the farmer's livestock can be put to pasture.
+
+## Scheduling: Fairshare and Backfill
+
+Pending jobs are assigned a priority- jobs with higher priority are run before lower priority jobs.  This priority is primarily calculated using the "fairshare algorithm" which looks at the usage by an account over a period of time.  Older usage is decayed using something like a half-life calculation so that current usage has the greater impact on the job's priority.
+
+There is an additional time factor which accounts for the amount of time a job has been waiting.  This and the fairshare factor are combined to calculate the job's priority- multipliers provide different weights to those factors.  The wait-time for a job has a very small factor and only ensures basic ordering of jobs for an account.
+
+The jobs with the highest priority are reserved resources- the scheduler identifies suitable resources which are or will be available and reserves those for the job.
+
+However, there is another mechanism for jobs to get resources.  Once those reservations are made, jobs which can fit onto idle resources and don't block those reservations can be allocated those resources.  This "backfill" mechanism allows lower priority jobs to run on otherwise unused nodes.
+
+### A Metaphor
+
+When the pasture is filling up it becomes necessary for the farmers to have more care in putting livestock into the field.  To do this, farmers who have had a lot of livestock grazing hold back putting more livestock out to allow those who have not been grazing to put out their herd.


### PR DESCRIPTION
Two pages in this PR.  The "compute_accounts" page contains details about what cluster accounts are and what comes with those.  The second, "compute_job_scheduling" is a bit of a deep dive into job scheduling.

I don't think this needs to be in the sidebar, but it does need a link into one of the other pages.  Likely the access page and maybe one of the other gizmo pages.  Need some ideas here.