### PR TITLE
Rework collaboration storage docs

### DIFF
--- a/_scicomputing/store_aspera.md
+++ b/_scicomputing/store_aspera.md
@@ -1,0 +1,15 @@
+---
+title: Aspera for Data Transfer
+last_modified_at: 2019-04-01
+primary_reviewers: vortexing
+---
+
+## Aspera
+
+The Aspera is a storage appliance that runs a heavily tuned storage server and client that enables fast transfer of large data between this system and a host using the Aspera client (either command line or via a browser).  The primary method of operation is to upload the data to the server, then use the web interface to create an email with a link you would then send to those outside the Hutch network.
+
+> Note: space is limited. Because of this, data stored here is deleted after a short period of time making the Aspera inappropriate for primary storage.  Always keep the primary source on one of the other options above (fast, economy, etc.)
+
+Note that the licence we have does not include use of the command line client (`ascp`).  The command line client can be used to move data with other sites which do have the license, but we can only use the web for our installation.
+
+Visit [the Aspera information page](https://aspera.fhcrc.org/index.html) for more details and information on using this storage service.

--- a/_scicomputing/store_collaboration.md
+++ b/_scicomputing/store_collaboration.md
@@ -1,28 +1,25 @@
 ---
-title: OneDrive 
+title: Data Storage for Collaboration
 last_modified_at: 2019-04-01
 primary_reviewers: vortexing
 ---
 
+There are Fred Hutch supported data storage systems that allow you to share data with people outside the Hutch, with or without a Hutch ID in order to facilitate data transfer and receipt in collaborations within or outside of the Fred Hutch.
+
+## Aspera
+
+The Aspera storage service is good for medium-sized data sets (up to <fixme> GB). Data stored here can be shared internally and externally.
+
+More information [here](store_aspera)
 
 ## OneDrive
-OneDrive is a cloud service that securely stores your files and folders in one place, share them with others, and update your files from any device. OneDrive is a benefit available individual users at the Fred Hutch that allows for private storage of files with the ability to share those files with others for collaboration.  With OneDrive you can:
 
-- Create documents on your computer and edit on your laptop, phone, or tablet
-- Collaborate with others in real time
-- View, store and share files and folders easily
-- Automatically sync files to your desktop for offline access
-- Simultaneously edit shared files with other collaborators
+OneDrive is a file storage cloud service from Microsoft.  This can be used for data of any volume _is this true?_.  Data can be shared internally and externally.
 
-The Fred Hutch service Office365 (which includes OneDrive) has been designed with security in mind and comes with features that help achieve compliance with regulations such as HIPAA and FISMA. With that said, the safety of your data depends not only on the design of OneDrive but also on how you use it. You also have control over more sharing options and the ability to restore a previous version of a file.  Your files are viewable only by users to whom you have granted access. Unless a file or folder has been shared, it will remain private.  Once you have installed the OneDrive application on a mobile device you will be able to upload and share documents between computers and devices as well.
+More information [here](store_onedrive)
 
-Visit the [OneDrive CenterNet page](https://centernet.fredhutch.org/cn/u/center-it/help-desk/onedrive.html) for more details and information on using this storage service.  As of Oct 2018 the [OneDrive Getting Started Guide](https://centernet.fredhutch.org/cn/u/center-it/help-desk/onedrive-getting-started.html) is available and currently free storage per user is limited to 2TB.  Please check the linked CenterNet pages for up to date information on OneDrive.
+## Economy Cloud (S3)
 
-Examples of best practices for using OneDrive include:
-  * Do not sync your Fred Hutch OneDrive with any non-Hutch device
-  * Do leave copies of sensitive data on a non-Hutch device from which you have accessed OneDrive
-  * Sharing Links: Do not select “Everyone” when sharing, instead choose the “Specific people” option whenever possible. If you choose the “People in Fred Hutchinson Cancer Research Center” option, anyone at the Center with a link to your shared file can access it.  
-  * Once a file is shared with someone and they download it to their device, they can share it with others.  File protection may also remain an appropriate practice.
-  * Links that share documents do NOT expire.  Remember to remove ability to share when no longer needed.
+Economy cloud buckets can also be configured to allow access to those outside your immediate group.
 
-> [See additional Best Practices in CenterNet.](https://centernet.fredhutch.org/cn/u/center-it/iso/o365-information-security-guidelines.html)
+More information [here](store_?)

--- a/_scicomputing/store_onedrive.md
+++ b/_scicomputing/store_onedrive.md
@@ -1,0 +1,28 @@
+---
+title: OneDrive 
+last_modified_at: 2019-04-01
+primary_reviewers: vortexing
+---
+
+
+## OneDrive
+OneDrive is a cloud service that securely stores your files and folders in one place, share them with others, and update your files from any device. OneDrive is a benefit available individual users at the Fred Hutch that allows for private storage of files with the ability to share those files with others for collaboration.  With OneDrive you can:
+
+- Create documents on your computer and edit on your laptop, phone, or tablet
+- Collaborate with others in real time
+- View, store and share files and folders easily
+- Automatically sync files to your desktop for offline access
+- Simultaneously edit shared files with other collaborators
+
+The Fred Hutch service Office365 (which includes OneDrive) has been designed with security in mind and comes with features that help achieve compliance with regulations such as HIPAA and FISMA. With that said, the safety of your data depends not only on the design of OneDrive but also on how you use it. You also have control over more sharing options and the ability to restore a previous version of a file.  Your files are viewable only by users to whom you have granted access. Unless a file or folder has been shared, it will remain private.  Once you have installed the OneDrive application on a mobile device you will be able to upload and share documents between computers and devices as well.
+
+Visit the [OneDrive CenterNet page](https://centernet.fredhutch.org/cn/u/center-it/help-desk/onedrive.html) for more details and information on using this storage service.  As of Oct 2018 the [OneDrive Getting Started Guide](https://centernet.fredhutch.org/cn/u/center-it/help-desk/onedrive-getting-started.html) is available and currently free storage per user is limited to 2TB.  Please check the linked CenterNet pages for up to date information on OneDrive.
+
+Examples of best practices for using OneDrive include:
+  * Do not sync your Fred Hutch OneDrive with any non-Hutch device
+  * Do leave copies of sensitive data on a non-Hutch device from which you have accessed OneDrive
+  * Sharing Links: Do not select “Everyone” when sharing, instead choose the “Specific people” option whenever possible. If you choose the “People in Fred Hutchinson Cancer Research Center” option, anyone at the Center with a link to your shared file can access it.  
+  * Once a file is shared with someone and they download it to their device, they can share it with others.  File protection may also remain an appropriate practice.
+  * Links that share documents do NOT expire.  Remember to remove ability to share when no longer needed.
+
+> [See additional Best Practices in CenterNet.](https://centernet.fredhutch.org/cn/u/center-it/iso/o365-information-security-guidelines.html)


### PR DESCRIPTION
Proposal for reorganizing collaboration storage information:

 - create TOC for three different storage solutions that can be used for collaboration
 - move onedrive and aspera into dedicated pages
 - does the current economy cloud page include information on setting up s3 for collaboration
 
NOT ready for prime time... the links don't work, just gauging to see if this might work for organizing this info