### PR TITLE
This is very short term interim documentation.

### DIFF
--- a/_scicomputing/software_R.md
+++ b/_scicomputing/software_R.md
@@ -89,7 +89,6 @@ You can run this with any version of `R` that is available on our shared computi
 Here are the steps to run this wrapper.
 
 * Grab a node using the [grabnode](/compdemos/first_rhino/#logging-on-to-gizmo-via-grabnode) command. Specify how many CPUs and how much memory you want, and how many days you want to have control of the node. Remember that you can launch `slurm` jobs within RStudio, so you may not need to ask for a lot of computing power for your RStudio machine.
-* Once you are on the node you grabbed, choose a version of `R` by using the [module load](/scicomputing/compute_environments/#how-to-use-environment-modules) command (`ml` for short). (Example: `fhR/4.0.2-foss-2019b`). **NOTE**: At present, `fhR/4.0.2-foss-2019b` is the *only* R module that will work with RStudio Server.
 * Run the `launch_rstudio_server` command. This will produce a URL that you can paste into your browser. (This URL only works inside the Hutch network, so you need to be on campus or using VPN.)
 * In your browser, log into RStudio using your HutchNet ID and password.
 * If you have problems loading packages in RStudio Server, Try this: `.libPaths(c("/app/software/fhR/4.0.2-foss-2019b", .libPaths()))` 


### PR DESCRIPTION
I need to deploy an updated
launch script (which behaves slightly differently) before I can roll out
the web application that enables launching RStudio Server from
a browser -- it depends on these changes.

I removed the bit about loading an R module before running the script,
this is no longer needed and will produce an error message.

This will all be moot soon - within a couple of days at most - when the web
app is rolled out.