### PR TITLE
Add instructions and infrastructure for building on rhino

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "_vendor/bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _site/
 
 Gemfile.lock
 *.code-workspace
+_vendor/*

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ To contribute to the Wiki you only need to have your GitHub username added to th
 
 [Building a copy of this Wiki locally](#building-the-site-locally)
 
+[Building a copy of this Wiki on a rhino](#building-the-site-on-rhino)
+
 [For Admins](#for-admins)
 
 
@@ -105,7 +107,7 @@ Both Atom and VSCode will make a directory called `assets` in the directory wher
 
 #### Youtube
 
-When linking to videos like screencasts you typically want to show an image screenshot and clicking on that screenshot starts the video. Images of videos are stored at https://img.youtube.com/vi and they use the same video id you find in Youtube URLs, so The Gift of Time is ```https://youtu.be/rN7cmb1K2yA```. To embed, insert this into markdown:
+When linking to videos like screencasts you typically want to show an image screenshot and clicking on that screenshot starts the video. Images of videos are stored at https://img.youtube.com/vi and they use the same video id you find in Youtube URLs, so The Gift of Time is `https://youtu.be/rN7cmb1K2yA`. To embed, insert this into markdown:
 
     [![The Gift of Time](https://img.youtube.com/vi/rN7cmb1K2yA/0.jpg)](https://youtu.be/rN7cmb1K2yA "Click to see The Gift of Time")
 
@@ -209,6 +211,38 @@ links and the files they are found in.
 If you are inside the Fred Hutch network, you can type
 `rake testlocal` and that will include internal URLs
 in the check.
+
+## Building the site on rhino
+
+### Load a current Ruby version:
+
+```
+ml Ruby/2.7.2-GCCcore-10.2.0
+```
+
+### Install gems
+
+```
+bundle install
+```
+
+### Build
+
+```
+bundle exec jekyll build
+```
+
+### Serve
+
+```
+bundle exec jekyll serve -H <node IP address> -P <port>
+```
+
+Use the external IP for the host you're using.  Select an unused port over 1024.
+
+### View
+
+Point your browser at the IP and port combination you've specified in the `serve` command above.  Once this has started, the site will be rebuit when updates are made to any of the source files in the site.
 
 ## Glossary terms
 

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ Contributors List (note all markdowns in this folder will be rendered): https://
 
 Pathways page (note all markdowns in this folder will be rendered): https://github.com/FredHutch/wiki/tree/main/_pathways
 
-
 ###  Draft Folders with Templates for New Content
+
 >NOTE:  Any content that will need to be an entirely new page should be stored in the `draft` folder until it is ready for publication, and then an admin will move it to where it needs to go when it is considered finished.  
 
 For new content: https://github.com/FredHutch/wiki/blob/main/_drafts/contentTemplate.md
@@ -154,12 +154,9 @@ For new contributor entries: https://github.com/FredHutch/wiki/blob/main/_drafts
 
 ## Automated deployment
 
-Everything merged into the `main` branch
-will be automatically deployed to 
-[https://sciwiki.fredhutch.org](https://sciwiki.fredhutch.org).
+Everything merged into the `main` branch will be automatically deployed to [https://sciwiki.fredhutch.org/]https://sciwiki.fredhutch.org)
 
-Everything in any *other* branch pushed to GitHub will be deployed to 
-[https://sciwiki-preview.fredhutch.org](https://sciwiki-preview.fredhutch.org),
+Everything in any *other* branch pushed to GitHub will be deployed to [https://sciwiki-preview.fredhutch.org/](https://sciwiki-preview.fredhutch.org) ,
 which is only accessible inside the Fred Hutch network.
 You can check what branch and what commit is reflected by going to 
 [https://sciwiki-preview.fredhutch.org/info.txt](https://sciwiki-preview.fredhutch.org/info.txt).
@@ -227,6 +224,8 @@ If you are inside the Fred Hutch network, you can type
 in the check.
 
 ## Building the site on rhino
+
+This will
 
 ### Load a current Ruby version:
 


### PR DESCRIPTION
So my workflow is easiest when I build this on a rhino/gizmo type system for testing.  Works well with the Ruby installed in app but a couple changes make this much easier:

 - adding `.bundle/config` to install gems in _vendor
 - adding the _vendor directory to gitignore
 - adding some instructions

I'm only concerned that the bundle config will break the build- does anyone have any insights on that?