### PR TITLE
Deploy all branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ deploy_preview:
     - docker tag dockerimages.fhcrc.org/wiki:latest dockerimages.fhcrc.org/wiki-preview:latest 
     - docker push dockerimages.fhcrc.org/wiki-preview:latest
     - sleep 15
-    - rancher-v0.6.2/rancher --url https://ponderosa.fhcrc.org --access-key $PREVIEW_RANCHERAPI_KEY --secret-key $PREVIEW_RANCHERAPI_SECRET up -d --pull --force-upgrade --confirm-upgrade --stack wiki --file docker-compose-preview.yml --rancher-file rancher-compose.yml
+    - rancher-v0.6.2/rancher --url https://ponderosa.fhcrc.org --access-key $PREVIEW_RANCHERAPI_KEY --secret-key $PREVIEW_RANCHERAPI_SECRET up -d --pull --force-upgrade --confirm-upgrade --stack wiki_preview --file docker-compose-preview.yml --rancher-file rancher-compose.yml
 
 # deploy `main` branch to
 # https://sciwiki.fredhutch.org

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,9 +5,35 @@ before_script:
   
 build_test:
   script:
+    - echo Information > info.txt
+    - echo "Branch: ${CI_COMMIT_BRANCH}" >> info.txt
+    - echo "Commit: ${CI_COMMIT_SHA}" >> info.txt
+    - echo "Commit comment:" >> info.txt
+    - echo " ${CI_COMMIT_MESSAGE}" >> info.txt
+    - echo "Build time: $(date)" >> info.txt
     - docker build -t dockerimages.fhcrc.org/wiki:latest .
 
-  
+# build for every branch EXCEPT main and push to preview site
+# https://sciwiki-preview.fredhutch.org (only accessible inside
+# hutch network). See 
+# https://sciwiki-preview.fredhutch.org/info.txt for branch
+# and commit information.
+
+deploy_preview:
+  stage: deploy
+  except: 
+    refs:
+      - main
+  script:
+    - docker login --username $DOCKERIMAGES_USER --password $DOCKERIMAGES_PASS https://dockerimages.fhcrc.org
+    - docker tag dockerimages.fhcrc.org/wiki:latest dockerimages.fhcrc.org/wiki-preview-latest 
+    - docker push dockerimages.fhcrc.org/wiki-preview:latest
+    - sleep 15
+    - rancher-v0.6.2/rancher --url https://ponderosa.fhcrc.org --access-key $PREVIEW_RANCHERAPI_KEY --secret-key $PREVIEW_RANCHERAPI_SECRET up -d --pull --force-upgrade --confirm-upgrade --stack wiki --file docker-compose-preview.yml --rancher-file rancher-compose.yml
+
+# deploy `main` branch to
+# https://sciwiki.fredhutch.org
+
 deploy:
   stage: deploy
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ deploy_preview:
       - main
   script:
     - docker login --username $DOCKERIMAGES_USER --password $DOCKERIMAGES_PASS https://dockerimages.fhcrc.org
-    - docker tag dockerimages.fhcrc.org/wiki:latest dockerimages.fhcrc.org/wiki-preview-latest 
+    - docker tag dockerimages.fhcrc.org/wiki:latest dockerimages.fhcrc.org/wiki-preview:latest 
     - docker push dockerimages.fhcrc.org/wiki-preview:latest
     - sleep 15
     - rancher-v0.6.2/rancher --url https://ponderosa.fhcrc.org --access-key $PREVIEW_RANCHERAPI_KEY --secret-key $PREVIEW_RANCHERAPI_SECRET up -d --pull --force-upgrade --confirm-upgrade --stack wiki --file docker-compose-preview.yml --rancher-file rancher-compose.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,14 +4,14 @@ before_script:
   - tar zxf rancher-linux-amd64-v0.6.2.tar.gz
   
 build_test:
-  script:
-    - echo Information > info.txt
-    - echo "Branch: ${CI_COMMIT_BRANCH}" >> info.txt
-    - echo "Commit: ${CI_COMMIT_SHA}" >> info.txt
-    - echo "Commit comment:" >> info.txt
-    - echo " ${CI_COMMIT_MESSAGE}" >> info.txt
-    - echo "Build time: $(date)" >> info.txt
-    - docker build -t dockerimages.fhcrc.org/wiki:latest .
+  script: |
+    echo Information > info.txt
+    echo "Branch: ${CI_COMMIT_BRANCH}" >> info.txt
+    echo "Commit: ${CI_COMMIT_SHA}" >> info.txt
+    echo "Commit comment:" >> info.txt
+    echo " ${CI_COMMIT_MESSAGE}" >> info.txt
+    echo "Build time: $(date)" >> info.txt
+    docker build -t dockerimages.fhcrc.org/wiki:latest .
 
 # build for every branch EXCEPT main and push to preview site
 # https://sciwiki-preview.fredhutch.org (only accessible inside

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ FROM nginx
 
 COPY --from=0 /srv/jekyll/_site/ /usr/share/nginx/html
 RUN cp /usr/share/nginx/html/images/favicon.ico /usr/share/nginx/html/
+COPY ./info.txt /usr/share/nginx/html/
 
 
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The more focused, how-to style, Resource Library entries in both the Data Genera
 
 Both Articles and Resource Library entries are full-text searchable using the search feature (the magnifying glass in the header).  This search ability is the primary strength behind this Wiki and will be the primary way people will find content, as, again, no web designers or technical writers are involved in this grassroots project.  
 
-**NEW (as of March 2022)** - Introducing **Pathways**!  Pathways are a new approach we are incorporating which can be found by following the [Pathways link](https://sciwiki.fredhutch.org/pathways/) in the sidebar from any domain.  This Pathways page will host individual pages that provide users who want to do a commonly requested set of tasks, a list of pages/links in the order they'll want to read them, that will guide them along the pathway to doing what they want.  We hope this might be an alternate mode for finding content in the Wiki that the community finds useful.  If you have ideas for new Pathways, please [file an issue](https://github.com/FredHutch/wiki/issues) and tell us about it.  
+**NEW (as of March 2022)** - Introducing **Pathways**!  Pathways are a new approach we are incorporating which can be found by following the [Pathways link](/pathways/) in the sidebar from any domain.  This Pathways page will host individual pages that provide users who want to do a commonly requested set of tasks, a list of pages/links in the order they'll want to read them, that will guide them along the pathway to doing what they want.  We hope this might be an alternate mode for finding content in the Wiki that the community finds useful.  If you have ideas for new Pathways, please [file an issue](https://github.com/FredHutch/wiki/issues) and tell us about it.  
 
 ### Adding/Editing Content
 
@@ -54,7 +54,7 @@ To edit one of the content-containing markdowns (see below regarding Repo struct
     >Note: If you are editing existing content and the page has a listing for the Primary Reviewers like this:  `primary_reviewers: somegithubusername` then when you submit the pull request please request a review from those usernames.  
 
 5. Reviewers will sign off on edits by approving or providing comments on a pull request, ideally one "expert" and one "novice" based on field of expertise.  If there is a `primary_reviewers` listed for content then one of the reviews must be from one of those members.  Others may move your content to combine it with other work, or make edits that you may want to review as well.  Keep an eye on your pull requests and comments on it in order to check back in if someone's edits need your review as well.  
-6. Once approving reviews have been obtained, the pull request can be merged into the main branch and then any edits go live to the site [here.](https://sciwiki.fredhutch.org/)
+6. Once approving reviews have been obtained, the pull request can be merged into the main branch and then any edits go live to the site [here.](/)
 
 ### The Review Process
 
@@ -71,7 +71,7 @@ When a pull request is made, it automatically requests a pull request review fro
 Please remember to make a [markdown for yourself](https://github.com/FredHutch/wiki/blob/main/_drafts/contributorTemplate.md) in our `_contributors` directory so that we can give you credit for your contributions publicly on the site if you would like to.  
 
 ## Contributing via an external text editor
-You can also contribute to the wiki from external editors that can interoperate with GitHub. We have had good experience with [Atom](https://github.atom.io/) but other text editors have GitHub integration as well.  Also there is a tutorial on how to use [VSCode](https://sciwiki.fredhutch.org/compdemos/vscode_markdown_howto/) which is what you will want to use if you plan to contribute many screenshots or other images.  
+You can also contribute to the wiki from external editors that can interoperate with GitHub. We have had good experience with [Atom](https://github.atom.io/) but other text editors have GitHub integration as well.  Also there is a tutorial on how to use [VSCode](/compdemos/vscode_markdown_howto/) which is what you will want to use if you plan to contribute many screenshots or other images.  
 
 ## Wiki Content Style Guide
 ### Github-Flavored Markdown

--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ will be automatically deployed to
 [https://sciwiki.fredhutch.org](https://sciwiki.fredhutch.org).
 
 Everything in any *other* branch pushed to GitHub will be deployed to 
-[https://sciwiki-preview.fredhutch.org](https://sciwiki-preview.fredhutch.org). You can check what branch and what commit is reflected by going to 
+[https://sciwiki-preview.fredhutch.org](https://sciwiki-preview.fredhutch.org),
+which is only accessible inside the Fred Hutch network.
+You can check what branch and what commit is reflected by going to 
 [https://sciwiki-preview.fredhutch.org/info.txt](https://sciwiki-preview.fredhutch.org/info.txt).
 
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,18 @@ For new content: https://github.com/FredHutch/wiki/blob/main/_drafts/contentTemp
 
 For new contributor entries: https://github.com/FredHutch/wiki/blob/main/_drafts/contributorTemplate.md
 
+## Automated deployment
+
+Everything merged into the `main` branch
+will be automatically deployed to 
+[https://sciwiki.fredhutch.org](https://sciwiki.fredhutch.org).
+
+Everything in any *other* branch pushed to GitHub will be deployed to 
+[https://sciwiki-preview.fredhutch.org](https://sciwiki-preview.fredhutch.org). You can check what branch and what commit is reflected by going to 
+[https://sciwiki-preview.fredhutch.org/info.txt](https://sciwiki-preview.fredhutch.org/info.txt).
+
+
+
 
 ## Building the site locally
 

--- a/_compdemos/git_tips.md
+++ b/_compdemos/git_tips.md
@@ -149,13 +149,13 @@ More information on the main package can be found [here](https://atom.io/package
 - [Visual Studio Code](https://code.visualstudio.com) is an IDE also capable of handling multiple programming languages,
 and is the preferred interface for the Hutch's Scientific Computing group.
 A description of its Git interface is available [here](https://code.visualstudio.com/docs/editor/versioncontrol).
-More info on specific use in relation to Python is [here](https://sciwiki.fredhutch.org/scicomputing/software_python/#visual-studio-code).
+More info on specific use in relation to Python is [here](/scicomputing/software_python/#visual-studio-code).
 - [PyCharm](https://www.jetbrains.com/pycharm/) is an IDE primarily for Python.
 Information on its integration with git is [here](https://www.jetbrains.com/help/pycharm/using-git-integration.html#set-passwords-for-git-remotes);
-more info on specific use in relation to Python is [here](https://sciwiki.fredhutch.org/scicomputing/software_python/#pycharm)
+more info on specific use in relation to Python is [here](/scicomputing/software_python/#pycharm)
 - [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/index.html) is an interface for improving interactions with Jupyter notebooks.
 Information on JupyterLab's extension for Git is [here](https://github.com/jupyterlab/jupyterlab-git);
-more info on specific use in relation to Python is [here](https://sciwiki.fredhutch.org/scicomputing/software_python/#jupyter-notebooks).
+more info on specific use in relation to Python is [here](/scicomputing/software_python/#jupyter-notebooks).
 
 ## To Fork or Not to Fork?
 What a question!  Different GitHub repositories will have different procedures for how to contribute to them.  Ideally these procedures are outlined in the README or in the CONTIBUTING markdowns inside the repository itself, though sometimes they are less well documented.  When a GitHub repository is created, you have the option to allow or disallow forking (the default is currently to allow forking).  You also can limit who can make a branch on the repository and additional branch/user access limitations via options in the Settings tab, for `Managing Access` or `Branches`.  There are many options to control how users can interact with a repo that are far too extensive to discuss here.  

--- a/_compdemos/gizmo-bionic-changelog.md
+++ b/_compdemos/gizmo-bionic-changelog.md
@@ -14,7 +14,7 @@ Updated the NoMachine service with a valid .fhcrc.org certificate.  Now when you
 
 #### Enabled Arbiter
 
-Arbiter (the new [load management software](https://sciwiki.fredhutch.org/compdemos/rhino-load-management/) for the Rhino nodes) has been in debug mode for the past few weeks to get an idea of how well it would function with real load.  Thus far all appears well, so we've enabled this service to actually begin managing the load on the new Rhino nodes (i.e. enforcing limits and sending messages).
+Arbiter (the new [load management software](/compdemos/rhino-load-management/) for the Rhino nodes) has been in debug mode for the past few weeks to get an idea of how well it would function with real load.  Thus far all appears well, so we've enabled this service to actually begin managing the load on the new Rhino nodes (i.e. enforcing limits and sending messages).
 
 ### 7 July 2020
 

--- a/_compdemos/gizmo-bionic-known_issues.md
+++ b/_compdemos/gizmo-bionic-known_issues.md
@@ -93,7 +93,7 @@ The host key for the name "rhino" has changed as the name now points to a new ho
 
 #### Work Arounds / Fixes
 
-Remediation steps are platform and SSH client specific, but generally can be resolved by reviewing the documentation for your client on how to update "known hosts".  General steps are provided [here](https://sciwiki.fredhutch.org/compdemos/ssh_host_key_management/)
+Remediation steps are platform and SSH client specific, but generally can be resolved by reviewing the documentation for your client on how to update "known hosts".  General steps are provided [here](/compdemos/ssh_host_key_management/)
 
 ### Hostname "gizmo" Retired
 

--- a/_compdemos/microbiome_tools.md
+++ b/_compdemos/microbiome_tools.md
@@ -20,7 +20,7 @@ will be updated as more are made available.
 
 The tools below happen to use Nextflow as a system for running reproducible and
 portable analytical workflows. 
-See [this documentation](https://sciwiki.fredhutch.org/compdemos/nextflow/) 
+See [this documentation](/compdemos/nextflow/) 
 for more details on running Nextflow at Fred Hutch, as well as 
 [the docs](https://www.nextflow.io/) for more details on Nextflow itself.
 

--- a/_compdemos/nextflow.md
+++ b/_compdemos/nextflow.md
@@ -14,7 +14,7 @@ For more details on Nextflow and workflow managers overall, please visit the wor
 ### Example workflows
 Fred Hutch researchers are building and maintaining a set of Nextflow workflows for use by the general community [here](https://github.com/FredHutch/reproducible-workflows/tree/master/nextflow), while also providing an example of how to write your own workflows.
 
-Some Nextflow-based tools used for microbiome analysis at Fred Hutch can be found in [the accompanying documentation](https://sciwiki.fredhutch.org/compdemos/microbiome_tools/)
+Some Nextflow-based tools used for microbiome analysis at Fred Hutch can be found in [the accompanying documentation](/compdemos/microbiome_tools/)
 
 ### Setup
 

--- a/_compdemos/rslurm_example.md
+++ b/_compdemos/rslurm_example.md
@@ -20,7 +20,7 @@ The takehome message for this example is really on RSlurm. The idea is that one 
 - Some R programming experience
 - Familiarity running Rstudio or R on the Gizmos/Rhinos
 
-If you'd like to know more about using `sbatch` on the command line, see [this page](https://github.com/FredHutch/slurm-examples/tree/master/R_and_sh_example)  and [this page](https://sciwiki.fredhutch.org/scicomputing/compute_jobs/) for more information and some templates. Common slurm commands can also be found in the official SLURM [documentation](https://slurm.schedmd.com/sbatch.html).
+If you'd like to know more about using `sbatch` on the command line, see [this page](https://github.com/FredHutch/slurm-examples/tree/master/R_and_sh_example)  and [this page](/scicomputing/compute_jobs/) for more information and some templates. Common slurm commands can also be found in the official SLURM [documentation](https://slurm.schedmd.com/sbatch.html).
 
 ## Using RSlurm
 ### Requirements

--- a/_compdemos/rslurm_intro.md
+++ b/_compdemos/rslurm_intro.md
@@ -27,7 +27,7 @@ You will need access to the Rhinos for submitting the job
 
 ### Instructions on how to get set-up
 
-Log into a rhino or in an [NoMachine terminal session](https://sciwiki.fredhutch.org/scicomputing/access_methods/#nomachine-nx-multi-os).  Use the module commands to load R- most later versions of R in our environment have the `rslurm` module installed but it is also available for installation via CRAN
+Log into a rhino or in an [NoMachine terminal session](/scicomputing/access_methods/#nomachine-nx-multi-os).  Use the module commands to load R- most later versions of R in our environment have the `rslurm` module installed but it is also available for installation via CRAN
 
 ```
 > module purge

--- a/_compdemos/ucsc-track-s3.md
+++ b/_compdemos/ucsc-track-s3.md
@@ -29,7 +29,7 @@ By default, public buckets at the Hutch do not allow access (even with credentia
 
 You can use the AWS Command Line Interface (CLI) to upload files to S3, even before the CLD team has enabled the share on your public bucket.
 
-This Wiki contains some [basic instructions](https://sciwiki.fredhutch.org/compdemos/aws-s3/#aws-command-line-interface-cli) for interacting with S3 using the CLI, and AWS provides the [full documentation](https://docs.aws.amazon.com/cli/latest/reference/s3/).
+This Wiki contains some [basic instructions](/compdemos/aws-s3/#aws-command-line-interface-cli) for interacting with S3 using the CLI, and AWS provides the [full documentation](https://docs.aws.amazon.com/cli/latest/reference/s3/).
 
 The main thing to remember when uploading data for use with the UCSC Genome Browser is that the data will need to be publicly accessible, however this can be handled through the S3 bucket resource policy so your `aws s3 cp` or `aws s3 sync` commands **should** have the `--acl public-read` flag at the end.
 

--- a/_generation/data-viz.md
+++ b/_generation/data-viz.md
@@ -32,7 +32,7 @@ While it is possible to [plot using base R](https://bookdown.org/rdpeng/exdata/t
 - [Shiny](https://shiny.rstudio.com/)
   - [Learn Shiny](https://shiny.rstudio.com/tutorial/)
   - [Mastering Shiny - Hadley Wickham](https://mastering-shiny.org/)
-  - [Fred Hutch Biomedical Data Science Wiki entry on Shiny applications](https://sciwiki.fredhutch.org/compdemos/shiny/)
+  - [Fred Hutch Biomedical Data Science Wiki entry on Shiny applications](/compdemos/shiny/)
 
 #### Packages that extend `ggplot` capabilities
 - [ggbeeswarm](https://github.com/eclarke/ggbeeswarm)

--- a/_hdc/bioinformatics_library.md
+++ b/_hdc/bioinformatics_library.md
@@ -16,13 +16,13 @@ some additional listed below "Other services" that may be included eventually (b
 
 Sections from wiki, not represented in SR pages
 
-https://sciwiki.fredhutch.org/generation/datagen_platformsData/#library-preparation-for-sequencing
+/generation/datagen_platformsData/#library-preparation-for-sequencing
   - [Guide to library prep](https://genohub.com/ngs-library-preparation-kit-guide/): This guide is an overview of library preparation applications and kits that are in common use for next-generation sequencing.
   - [NGS library preperation resources from Illumina](https://www.illumina.com/techniques/sequencing/ngs-library-prep.html): Illumina library prep resource page.
   - [Illumina sequencing method explorer](https://www.illumina.com/science/sequencing-method-explorer.html): Use this tool to explore cutting-edge experimental next-generation sequencing (NGS) library preparation methods compiled from scientific literature. To find a method to suit your project, along with compatible kits, select a starting material or search for a method by name.
   - [Library construction for next-generation sequencing: Overviews and challenges](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4351865/): Factors such as the quantity and physical characteristics of the RNA or DNA source material as well as the desired application are addressed in the context of preparing high quality sequencing libraries.
 
-https://sciwiki.fredhutch.org/generation/datagen_assayPrep/
+/generation/datagen_assayPrep/
   - [Labome overview of RNA extraction kits and application’s](https://www.labome.com/method/RNA-Extraction.html): This article summarizes commonly used methods and kits for RNA extraction.
   - [Labome overview of DNA extraction kits and applications](https://www.labome.com/method/DNA-Extraction-and-Purification.html): A comprehensive review of DNA extraction and purification kits cited in the literature.
 
@@ -32,21 +32,21 @@ https://sciwiki.fredhutch.org/generation/datagen_assayPrep/
 
 - [Illumina Sequencing by Synthesis](https://www.youtube.com/watch?v=fCd6B5HRaZ8): A 5 min video covering the Illumina RNA sequencing technology.
 
-https://sciwiki.fredhutch.org/generation/datagen_platformsData/#illumina-sequencers
+/generation/datagen_platformsData/#illumina-sequencers
   - [Illumina sequencing resources](https://www.illumina.com/techniques/sequencing.html): Sequencing resources page on the Illumina website.
 
 ### PacBio
 
-https://sciwiki.fredhutch.org/generation/datagen_platformsData/#pacific-biosciences-pacbio-long-range-sequencer
+/generation/datagen_platformsData/#pacific-biosciences-pacbio-long-range-sequencer
   - [SMRT Sequencing](https://www.pacb.com/smrt-science/smrt-sequencing/): Resources about the SMRT sequencing technology from PacBio.
 
-https://sciwiki.fredhutch.org/generation/datagen_dnaApproaches/#smrt-sequencing-pacbio
+/generation/datagen_dnaApproaches/#smrt-sequencing-pacbio
 
 ### Sanger
 
 ### 10X genomics
 
-https://sciwiki.fredhutch.org/generation/datagen_platformsData/#10x-genomics-single-cell-library-preparation-system
+/generation/datagen_platformsData/#10x-genomics-single-cell-library-preparation-system
   - [10x genomics](https://www.10xgenomics.com/): Link to the 10X genomics webpage
 
 ### Microarrays
@@ -54,7 +54,7 @@ https://sciwiki.fredhutch.org/generation/datagen_platformsData/#10x-genomics-sin
 Should we include this?
 Not mentioned on SR genomics page, but may be listed elsewhere?
 
-https://sciwiki.fredhutch.org/generation/datagen_dnaApproaches/#dna-microarrays
+/generation/datagen_dnaApproaches/#dna-microarrays
   - [Methylation arrays](https://www.illumina.com/techniques/microarrays/methylation-arrays.html): Illumina resource covering Methylation arrays
   - [Genotyping arrays](https://www.illumina.com/techniques/popular-applications/genotyping.html): Illumina resource covering genotyping.
 
@@ -69,16 +69,16 @@ Subheadings from https://www.fredhutch.org/en/research/shared-resources/core-fac
 - [University of Oregon RNA-seqlopedia](https://rnaseq.uoregon.edu/)
 - [Introduction to RNA-seq for researchers](https://www.youtube.com/watch?v=7BLS_YY9HeM&t=758s): A 30 min video reviewing RNA-sequencing concepts.
 
-https://sciwiki.fredhutch.org/generation/datagen_rnaApproaches/#rna-sequencing
+/generation/datagen_rnaApproaches/#rna-sequencing
    - [Illumina gene expression resource](https://www.illumina.com/techniques/popular-applications/gene-expression-transcriptome-analysis.html): Illumina resources for gene expression analysis.
 
-https://sciwiki.fredhutch.org/generation/datagen_rnaApproaches/#qualitative-approaches-transcript-and-splicing-discovery
+/generation/datagen_rnaApproaches/#qualitative-approaches-transcript-and-splicing-discovery
 
 #### small RNAs (e.g., miRNA)
 
 Not specifically mentioned in SR pages?
 
-https://sciwiki.fredhutch.org/generation/datagen_rnaApproaches/#example--small-rnas-eg-mirna
+/generation/datagen_rnaApproaches/#example--small-rnas-eg-mirna
   - [Genohub guide on small RNA (miRNA)](https://genohub.com/services/sequencing/illumina-miRNA-sequencing-services): Use this guide to help search for and get accurate pricing and turnaround times for small RNA, microRNA (miRNA) sequencing services. The guide includes considerations you should make before starting your small RNA sequencing project.
 
 ### Cleavage Under Targets and Release Using Nuclease (CUT&RUN)
@@ -93,7 +93,7 @@ https://sciwiki.fredhutch.org/generation/datagen_rnaApproaches/#example--small-r
 - [Roche: whole exome sequencing](https://sequencing.roche.com/en/research-application/application/whole-exome-sequencing.html): A brief overview of whole exome sequencing from Roche
 - [The promise of whole-exome sequencing in medical genetics](https://www.nature.com/articles/jhg2013114): A summar of the impacts of whole-exome sequencing in medical genetics.
 
-https://sciwiki.fredhutch.org/generation/datagen_dnaApproaches/#capture-based-sequencing---example--whole-exome-sequencing
+/generation/datagen_dnaApproaches/#capture-based-sequencing---example--whole-exome-sequencing
 
 ### Targeted sequencing
 
@@ -101,7 +101,7 @@ https://sciwiki.fredhutch.org/generation/datagen_dnaApproaches/#capture-based-se
 - [Disease-targeted sequencing: a cornerstone in the clinic](https://www.nature.com/articles/nrg3463): A review of disease targeted sequencing and it's clinical applications.
 - [Applications and analysis of targeted genome sequencing in cancer studies](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6861594/): A review of how targeted sequencing is used in cancer research. This paper also presents a generalized workflow, explaining important parmeters and best practices.
 
-https://sciwiki.fredhutch.org/generation/datagen_dnaApproaches/#amplicon-based-sequencing---targeted-dna-sequencing
+/generation/datagen_dnaApproaches/#amplicon-based-sequencing---targeted-dna-sequencing
   - [Optimizing coverage for targeted sequencing](https://support.illumina.com/content/dam/illumina-marketing/documents/products/technotes/technote_optimizing_coverage_for_targeted_resequencing.pdf): This tech note from Illumina describes how targeted DNA sequencing panels are designed and sequenced to maximize the data quality and coverage when used.
 
 ### CRISPR screens
@@ -112,7 +112,7 @@ https://sciwiki.fredhutch.org/generation/datagen_dnaApproaches/#amplicon-based-s
 
 ### ChIPseq
 
-https://sciwiki.fredhutch.org/generation/datagen_dnaApproaches/#chromatin-immunoprecipitation-sequencing-chip-seq
+/generation/datagen_dnaApproaches/#chromatin-immunoprecipitation-sequencing-chip-seq
   - [Epigenie guide to ChIPseq](https://epigenie.com/guide-getting-started-with-chip-seq/): An overview of ChIP sequencing. A good starting point with references and resources linking to more information.
 
 ### ATACseq (DNA accessibility)
@@ -132,7 +132,7 @@ https://sciwiki.fredhutch.org/generation/datagen_dnaApproaches/#chromatin-immuno
 Should we include this?
 Not mentioned on SR genomics page, but may be listed elsewhere?
 
-https://sciwiki.fredhutch.org/generation/datagen_dnaApproaches/#reduced-representation-bisulfite-sequencing-rrbs
+/generation/datagen_dnaApproaches/#reduced-representation-bisulfite-sequencing-rrbs
   - [Babraham's guide to RRBS](http://www.bioinformatics.babraham.ac.uk/projects/bismark/RRBS_Guide.pdf)
 
 ### Nanostring
@@ -141,9 +141,9 @@ Should we include this,
 perhaps with RNAseq under a subheading of "gene expression"?
 Not mentioned on SR genomics page, but may be listed elsewhere?
 
-https://sciwiki.fredhutch.org/generation/datagen_platformsData/#single-nucleotide-polymorphism-snp-arrays-or-methylation-arrays
+/generation/datagen_platformsData/#single-nucleotide-polymorphism-snp-arrays-or-methylation-arrays
   - [Nanostring](https://www.nanostring.com/): Link to the Nanostring website.
   - [Illumina microarray](https://www.illumina.com/techniques/microarrays.html): Illumina resources on their microarray technology.
 
-https://sciwiki.fredhutch.org/generation/datagen_rnaApproaches/#nanostring-gene-expression-panels
+/generation/datagen_rnaApproaches/#nanostring-gene-expression-panels
   - [Illumina gene expression & transcriptome analysis](https://www.illumina.com/techniques/popular-applications/gene-expression-transcriptome-analysis.html): Resources on gene expression methods and analysis from Illumina.

--- a/_scicompannounce/2019-01-22-hpc-systems-upgrade-2019.md
+++ b/_scicompannounce/2019-01-22-hpc-systems-upgrade-2019.md
@@ -32,11 +32,11 @@ For this upgrade we plan to use a phased approach that will not require taking t
 
 During this upgrade we will be upgrading the operating system used on each server to [Ubuntu 18.04LTS](https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes#New_features_in_18.04). There will be no change to the hardware currently used in our HPC environment or change in the computing capacity.  
 
-This operating system upgrade requires that we rebuild the tools in the [/app file system](https://sciwiki.fredhutch.org/computing/cluster_software/) on the new OS using a new toolchain. At this time, we don’t know the full extent of the changes required at this time. Additional information will be provided as this work proceeds. 
+This operating system upgrade requires that we rebuild the tools in the [/app file system](/computing/cluster_software/) on the new OS using a new toolchain. At this time, we don’t know the full extent of the changes required at this time. Additional information will be provided as this work proceeds. 
 
 ## Future Communications 
 
-Throughout this upgrade Scientific Computing staff will send announcements, additional technical details and schedule updates via the [scicomp_announce mailing list](https://lists.fhcrc.org/mailman/listinfo/scicomp-announce) and the [Scientific Computing Announcements](https://sciwiki.fredhutch.org/scicompannounce/) page on SciWiki. Scientific Computing staff will also hold weekly open houses where you can come and run your jobs on the new operating system. If any problems are found, we will be on-hand to help you update your jobs and get them working. 
+Throughout this upgrade Scientific Computing staff will send announcements, additional technical details and schedule updates via the [scicomp_announce mailing list](https://lists.fhcrc.org/mailman/listinfo/scicomp-announce) and the [Scientific Computing Announcements](/scicompannounce/) page on SciWiki. Scientific Computing staff will also hold weekly open houses where you can come and run your jobs on the new operating system. If any problems are found, we will be on-hand to help you update your jobs and get them working. 
 
 As always, please email us at scicomp at fhcrc.org with any questions and concerns. 
 

--- a/_scicompannounce/2019-02-21-upgrade-env-modules.md
+++ b/_scicompannounce/2019-02-21-upgrade-env-modules.md
@@ -6,13 +6,13 @@ Hello to all Data Scientists and HPC Users!
 
 We hope you are already aware of our upcoming Operating System (OS) upgrade - we are updating all Linux systems from Ubuntu 14.04 to Ubuntu 18.04.
 
-[First Announcement](https://sciwiki.fredhutch.org/scicompannounce/2019-01-22-hpc-systems-upgrade-2019/)
+[First Announcement](/scicompannounce/2019-01-22-hpc-systems-upgrade-2019/)
 
 [Second Announcement](https://fredhutch.github.io/easybuild-life-sciences/announcements/2019-01-24_Upgrade/)
 
 There will be changes to our Environment Modules. Please refresh your understanding of Environment Modules.
 
-[Environment Module Information](https://sciwiki.fredhutch.org/computing/cluster_software/)
+[Environment Module Information](/computing/cluster_software/)
 
 The list of available Environment Modules on the new OS is different, and this may affect your scripts.
 
@@ -41,8 +41,8 @@ Links:
 
 [OS Upgrade Announcement One](https://fredhutch.github.io/easybuild-life-sciences/announcements/2019-01-24_Upgrade/)
 
-[OS Upgrade Announcement Two](https://sciwiki.fredhutch.org/scicompannounce/2019-01-22-hpc-systems-upgrade-2019/)
+[OS Upgrade Announcement Two](/scicompannounce/2019-01-22-hpc-systems-upgrade-2019/)
 
-[Environment Modules Information](https://sciwiki.fredhutch.org/computing/cluster_software/)
+[Environment Modules Information](/computing/cluster_software/)
 
 [18.04 (new) Environment Module list](http://fredhutch.github.io/easybuild-life-sciences/all-modules-18.04/)

--- a/_scicomputing/access_overview.md
+++ b/_scicomputing/access_overview.md
@@ -3,7 +3,7 @@ title: Computing Access Overview
 last_modified_at: 2019-09-05
 primary_reviewers: vortexing
 ---
-This overview describes what types of credentials are needed for [various Fred Hutch computing resources](https://sciwiki.fredhutch.org/compdemos/) and provides instructions for accessing those supported computing resources.
+This overview describes what types of credentials are needed for [various Fred Hutch computing resources](/compdemos/) and provides instructions for accessing those supported computing resources.
 
 ## [Credentials](/scicomputing/access_credentials/)
 This section details [how to get credentials and access](/scicomputing/access_credentials/) to campus and cloud-based computing systems such as HutchNetID, Github, AWS, and Rhino/Gizmo as well as others.

--- a/_scicomputing/compute_overview.md
+++ b/_scicomputing/compute_overview.md
@@ -60,5 +60,5 @@ every week.  Dates and details for SciComp office hours can be found in
 
 Graphical Processing Units (GPUs) provide acceleration for some kinds of computations and tools, [tensorflow](https://www.tensorflow.org/) is a notable example of such a tool.
 
-[This page](/scicomputing/compute_gpu/) describes in general where you can find those resources and how to request those for your jobs.  [This](https://sciwiki.fredhutch.org/compdemos/tensorflow-gpu/) has a specific example of running tensorflow on SciComp clusters.
+[This page](/scicomputing/compute_gpu/) describes in general where you can find those resources and how to request those for your jobs.  [This](/compdemos/tensorflow-gpu/) has a specific example of running tensorflow on SciComp clusters.
 

--- a/_scicomputing/software_R.md
+++ b/_scicomputing/software_R.md
@@ -142,7 +142,7 @@ knitr::opts_chunk$set(dev="CairoPNG")
 The [Tidyverse](https://www.tidyverse.org/) is a group of R packages that coordinate together and are commonly used for manipulating and  visualizing data in data science applications.  There are a number of useful packages for research based users that are part of the Tidyverse, and it's worth the time to learn about them and see how one might employ them to clean, analyze and convey data and results.  DataCamp has an online [Introduction to the Tidyverse](https://www.datacamp.com/courses/introduction-to-the-tidyverse) that can be useful when first evaluating whether these packages might be useful.  
 
 ## Shiny
-[Shiny](https://shiny.rstudio.com/) is an R package bundled with RStudio that enables the creation of interactive applications powered by R code. These apps can be viewed on any computer running RStudio, or they can be hosted on a server. Scicomp provides instructions for hosting Shiny apps [here](https://sciwiki.fredhutch.org/compdemos/shiny/).
+[Shiny](https://shiny.rstudio.com/) is an R package bundled with RStudio that enables the creation of interactive applications powered by R code. These apps can be viewed on any computer running RStudio, or they can be hosted on a server. Scicomp provides instructions for hosting Shiny apps [here](/compdemos/shiny/).
 
 ## Local resources
 - [Seattle useR group](http://www.meetup.com/Seattle-useR/)

--- a/_scicomputing/software_examples.md
+++ b/_scicomputing/software_examples.md
@@ -26,7 +26,7 @@ Other groups have developed templates for more general use:
 These repositories were created by Fred Hutch researchers and staff, and contain a variety of curated example code with documentation.
 
 - [Data Science Example Code](https://github.com/FredHutch/data-science-examples): Example code for a variety of common data science analysis tasks, longer than what appears in the [Resource Library](/compdemos/), but not so long as to warrant their own repositories.
-- [Slurm examples](https://github.com/FredHutch/slurm-examples): Examples of using Slurm (the [job management system](https://sciwiki.fredhutch.org/scicomputing/compute_overview/#job-management) used on our cluster) for life sciences research tasks.
+- [Slurm examples](https://github.com/FredHutch/slurm-examples): Examples of using Slurm (the [job management system](/scicomputing/compute_overview/#job-management) used on our cluster) for life sciences research tasks.
 - [Batch pipeline](https://github.com/FredHutch/batch_pipeline): Example workflows for a multi-step array job on AWS Batch (cloud computing)
 - [Python examples](https://github.com/FredHutch/community_groups/blob/master/python_coding.md#examples): discussed and aggregated by the Python User Group at Fred Hutch.
 - [Nextflow examples](https://github.com/FredHutch?utf8=✓&q=nf&type=&language=): this link shows all repositories containing Nextflow (`nf`) examples in the Fred Hutch GitHub organization. Each repository represents a different kind of analysis.  

--- a/docker-compose-preview.yml
+++ b/docker-compose-preview.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  wiki:
+    image: dockerimages.fhcrc.org/wiki-preview:latest
+    stdin_open: true
+    ports:
+      - "80"
+    labels:
+      io.rancher.container.pull_image: always

--- a/outreach.md
+++ b/outreach.md
@@ -9,19 +9,19 @@ sidebar:
   nav: "generic"
 ---
 
-The [Biomedical Data Science Wiki](https://sciwiki.fredhutch.org/) aims to support ongoing biomedical research now and in the future and is the product of the Fred Hutch research community. The ongoing contribution and curation of the content in the Wiki by the Fred Hutch researcher community itself is intended to serve two purposes:
+The [Biomedical Data Science Wiki](/) aims to support ongoing biomedical research now and in the future and is the product of the Fred Hutch research community. The ongoing contribution and curation of the content in the Wiki by the Fred Hutch researcher community itself is intended to serve two purposes:
 
 1. create an evolving source of documentation that grows and changes along with the particular interests and research tools available to Fred Hutch researchers over time, and
 2. unify content that bridges the divide between how research processes are performed *in general* and how those processes are performed at the Fred Hutch *specifically*.
 
-To fulfill these two purposes we have the Wiki Writer/Editor program which is intended to engage current Fred Hutch based postdocs, staff scientists and research specialists over a three month timeframe to create and edit content to help the [Biomedical Data Science Wiki](https://sciwiki.fredhutch.org/) achieve those goals. We aim to incorporate information about new and emerging technologies or projects in which Fred Hutch researchers are involved or use, and also provide a mechanism for feedback regarding what additional documentation is needed to support their research.
+To fulfill these two purposes we have the Wiki Writer/Editor program which is intended to engage current Fred Hutch based postdocs, staff scientists and research specialists over a three month timeframe to create and edit content to help the [Biomedical Data Science Wiki](/) achieve those goals. We aim to incorporate information about new and emerging technologies or projects in which Fred Hutch researchers are involved or use, and also provide a mechanism for feedback regarding what additional documentation is needed to support their research.
 
 > Note: as of the pandemic, the funded Writer/Editor program is on hiatus, but any contributions pro bono are still accepted.  
 
-## Suggestions for Contributing to the [Biomedical Data Science Wiki](https://sciwiki.fredhutch.org/)
+## Suggestions for Contributing to the [Biomedical Data Science Wiki](/)
 
-- Editing any existing content on the [SciWiki](https://sciwiki.fredhutch.org/) for accuracy, readability, and brevity.
-- Tackling some [issues](https://github.com/FredHutch/wiki/issues) on the [SciWiki](https://sciwiki.fredhutch.org/)
+- Editing any existing content on the [SciWiki](/) for accuracy, readability, and brevity.
+- Tackling some [issues](https://github.com/FredHutch/wiki/issues) on the [SciWiki](/)
 - Adopting a realm or page to build and evolve content about a specific topic you see missing.  
 - Adding a demo or detailed instructions on using a resource, performing a common task, setting up a tool for use in either our [Data Generation Resource Library](/generationdemos/), or the [Scientific Computing Resource Library](/compdemos/). 
 - Propose a new [Pathway](/pathways/). 
@@ -36,7 +36,7 @@ To fulfill these two purposes we have the Wiki Writer/Editor program which is in
 
 ## Why be a Wiki Writer/Editor?
 
-- Communicate with the research community and help improve the [Biomedical Data Science Wiki](https://sciwiki.fredhutch.org/)
+- Communicate with the research community and help improve the [Biomedical Data Science Wiki](/)
 - Share and communicate out how to use a new tool or resource
 - Document something you find yourself explaining multiple times to your co-workers( ex. best practices, getting started, how to, things to avoid, TL;DR)
 - Get better at using GitHub
@@ -46,7 +46,7 @@ To fulfill these two purposes we have the Wiki Writer/Editor program which is in
 
 - An initial one hour meeting for training on how to edit and manage contributions via GitHub (web OR desktop client training will be provided; previous experience with Github is not required).
 - Participate remotely or locally in the one hour weekly working meeting.
-- Write documentation in your primary area of expertise and/or editing existing documents on the [Biomedical Data Science Wiki](https://sciwiki.fredhutch.org/) both in and outside of your primary area of expertise. This work is done remotely, anytime during the week at your convenience and contributions are submitted regularly via GitHub. Contributions are then reviewed and incorporated along with all other contributions at the weekly Data Science Wiki work meeting.
+- Write documentation in your primary area of expertise and/or editing existing documents on the [Biomedical Data Science Wiki](/) both in and outside of your primary area of expertise. This work is done remotely, anytime during the week at your convenience and contributions are submitted regularly via GitHub. Contributions are then reviewed and incorporated along with all other contributions at the weekly Data Science Wiki work meeting.
 - Provide reviews of content for formatting, clarity and accuracy (when in your area of expertise) when other contributors submit pull requests.
 
 ## Ideal Writer/Editor Qualities

--- a/rancher-compose-yml
+++ b/rancher-compose-yml
@@ -1,5 +1,5 @@
 version: '2'
 services:
-  wiki:
+  wiki_preview:
     scale: 1
     start_on_create: true


### PR DESCRIPTION
As [documented](https://github.com/FredHutch/wiki/blob/deploy-all-branches/README.md#automated-deployment) in the README in this PR,

Everything merged into the `main` branch
will be automatically deployed to 
[https://sciwiki.fredhutch.org](https://sciwiki.fredhutch.org).

Everything in any *other* branch pushed to GitHub will be deployed to 
[https://sciwiki-preview.fredhutch.org](https://sciwiki-preview.fredhutch.org),
which is only accessible inside the Fred Hutch network.
You can check what branch and what commit is reflected by going to 
[https://sciwiki-preview.fredhutch.org/info.txt](https://sciwiki-preview.fredhutch.org/info.txt).

This is actually already live (so check it out), because it does not need to be merged into main in order to take effect. When I pushed these commits it triggered the functionality. When it is merged into main, nothing new will happen because this functionality only happens with branches that are not main.

