### PR TITLE
Clarify that bucket name field should be left blank in swift cloud co…

### DIFF
--- a/_compdemos/motuz.md
+++ b/_compdemos/motuz.md
@@ -54,7 +54,7 @@ To create a connection to a Swift location, you will need your Fred Hutch ID, yo
 
   **Basic**
   - Connection Name:  Anything you'd like to show up in the lists
-  - Bucket Name: Unnecessary
+  - Bucket Name: *leave this blank*
   - Auth URL: "https://tin.fhcrc.org/auth/v2.0"
   - Tenant: Of the format: "AUTH_Swift_lastname_f" with lastname_f being the last name and first initial of the PI
   


### PR DESCRIPTION
…nnection

...believe it or not, someone put **Unnecessary** into this field.