### PR TITLE
DON'T MERGE THIS YET - Update to ruby 3.0.1, eliminates warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # build me as fredhutch/wiki
 
-FROM ruby:2.7.1
+FROM ruby:3.0.1
 
 # FROM ubuntu:18.04
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,15 +5,18 @@ group :jekyll_plugins do
 end
 group :development, :test do
   gem "github-pages", group: :jekyll_plugins
-  gem 'jekyll-redirect-from', '~> 0.14.0'
-  gem 'jekyll-sitemap', '~> 1.2.0'
-  gem "nokogiri", ">= 1.10.4"
-  gem 'jekyll-toc', '~> 0.6.0'
+  gem 'jekyll'
+  gem 'jekyll-redirect-from'
+  gem 'jekyll-sitemap'
+  gem "nokogiri"
+  gem 'jekyll-toc'
   gem 'jekyll-include-cache'
-  gem 'jekyll-gist', '~> 1.5.0'
-  gem 'jekyll-remote-theme', '~> 0.3.0'
-  gem 'jemoji', '~> 0.10.0'
-  gem 'html-proofer', '~> 3.14.0'
-  gem 'rake', '~> 12.3.0'
-  gem 'faraday', '~> 0.17'
+  gem 'jekyll-gist'
+  gem 'jekyll-remote-theme'
+  gem 'jemoji'
+  gem 'html-proofer'
+  gem 'rake'
+  gem 'faraday'
+  gem 'webrick'
 end
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,22 @@
 source 'http://rubygems.org'
 
 group :jekyll_plugins do
-  gem 'jekyll-glossary_tooltip'
+  gem 'jekyll-glossary_tooltip', '~> 1.4.0'
 end
 group :development, :test do
-  gem "github-pages", group: :jekyll_plugins
-  gem 'jekyll'
-  gem 'jekyll-redirect-from'
-  gem 'jekyll-sitemap'
-  gem "nokogiri"
-  gem 'jekyll-toc'
-  gem 'jekyll-include-cache'
-  gem 'jekyll-gist'
-  gem 'jekyll-remote-theme'
-  gem 'jemoji'
-  gem 'html-proofer'
-  gem 'rake'
-  gem 'faraday'
-  gem 'webrick'
+  gem "github-pages", '~> 227', group: :jekyll_plugins
+  gem 'jekyll', '~> 3.9.2'
+  gem 'jekyll-redirect-from', '~> 0.16.0'
+  gem 'jekyll-sitemap', '~> 1.4.0'
+  gem "nokogiri", '~> 1.13.7'
+  gem 'jekyll-toc', '~> 0.17.1'
+  gem 'jekyll-include-cache', '~> 0.2.1'
+  gem 'jekyll-gist', '~> 1.5.0'
+  gem 'jekyll-remote-theme', '~> 0.4.3'
+  gem 'jemoji', '~> 0.12.0'
+  gem 'html-proofer', '~> 4.2.0'
+  gem 'rake', '~> 13.0.6'
+  gem 'faraday', '~> 2.3.0'
+  gem 'webrick', '~> 1.7.0'
 end
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ First, clone the repo on a rhino and check out the branch or commit you want to 
 ### Load a current Ruby version:
 
 ```
-ml Ruby/2.7.2-GCCcore-10.2.0
+ml Ruby/3.0.1-GCCcore-11.2.0
 ```
 
 ### Install gems

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,7 @@
 # to see the built site.
 
 bundle update
+gem install bundler:2.3.5
 gem install -g Gemfile
 bundle install
 bundle exec jekyll serve -H 0.0.0.0 -P 7979

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -12,4 +12,4 @@ echo Press Enter to continue the build or control-C to quit.
 
 read
 
-docker run  --name wiki-build --rm -v $(pwd):/work -w /work -p 7979:7979 ruby:2.7.1 ./build.sh
+docker run  --name wiki-build --rm -v $(pwd):/work -w /work -p 7979:7979 ruby:3.0.1 ./build.sh


### PR DESCRIPTION
DON'T WANT TO MERGE straightaway, let's discuss first.

The goal of this PR is to eliminate the copious warnings that show up when building the site:

```
/home/dtenenba/dev/wiki/_vendor/bundle/ruby/2.7.0/gems/jekyll-3.8.5/lib/jekyll/document.rb:449: warning: Using the last argument as keyword parameters is deprecated
...repeats ad nauseam...
```

Deprecation warnings often turn into errors in later versions of software, so it's best not to ignore them.
To that end, this PR updates Ruby to 3.0.1 (not the latest version available, but the latest for which there is an Easybuild recipe ready to go, so the latest available on the rhinos/gizmos). 

Also, version pins are removed from Gemfile. I am not sure about the wisdom of leaving it like this. I removed them so that we would get the latest versions of all packages. But now that I've done that, perhaps we should re-pin each package to its current version so no breaking changes or regressions can bite us. I may add a commit that re-pins the package versions.

I have tested this (and it works) with:

* GitLab CI build
* Docker build instructions (in README)
* Rhino build instructions (in README)

I have *not* tested it with the "local" build instructions in README because I've had trouble installing Ruby-3.0.1 on my local machines (for different reasons). 
So one more reason we may want to hesitate on this.

At any rate, if those warnings ever do turn into errors, merging this ought to fix the problem.

Reasons we might want to have a discussion before merging this are:

* People may want to make sure they can set up a local Ruby 3.0.1-based build setup before we make it the default.
* This is taking us further down the road away from the way GitHub Pages does things. If we ever want to go back to GitHub pages we'll need to change more things back. I don't think we plan to do that, but it's worth mentioning. The original motivation to move away from Pages was to be able to use plugins (like `jekyll-glossary_tooltip`) that are not supported there, and I don't think we want to give that up.
