### PR TITLE
Delete "gizmo" from title 

### DIFF
--- a/_pathways/path-batch-computing.md
+++ b/_pathways/path-batch-computing.md
@@ -1,5 +1,5 @@
 ---
-title: Run a Non-Interactive Job on Gizmo
+title: Run a Non-Interactive Job on the Cluster
 main_author: Michael Gutteridge
 primary_reviewers: atombaby, vortexing
 ---


### PR DESCRIPTION
We briefly discussed this in our meeting today. 

The term "gizmo" kinda throws me off since I didn't know what "gizmo" was referring to but was looking for basic non-interactive job commands. Would probably be better for users if the word Gizmo was removed from the title. 

This is my first PR on this SciWIki. Please let me know what you would prefer as far as the PR process. Hope to contribute more PRs in the future if that would be helpful! 
