### PR TITLE
Use local elasticsearch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.gitignore
+tmp/
+*.gz
+rancher-v0.6.2
+elasticsearch/
+.gitlab-ci.yml

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 .vscode/
 _site/
 .idea/*
-
 Gemfile.lock
 *.code-workspace
 _vendor/*
+info.txt
+tmp/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ build_test:
     docker network create wiki-indexer || true
     # run an instance of elasticsearch
     docker rm -f elasticsearch || true
-    docker run --network wiki-indexer -d --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" elasticsearch:8.4.0
+    docker run --network wiki-indexer -d --rm --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" elasticsearch:8.4.0
     sleep 20
     # create sciwiki0 index
     curl -X PUT "http://localhost:9200/sciwiki0/" -H 'Content-Type: application/json'
@@ -53,6 +53,7 @@ build_test:
     docker build -t indexer elasticsearch/
     # run indexer script
     docker run --network wiki-indexer -d --rm --name indexer -v $(pwd)/tmp:/html indexer
+    curl -X POST "http://localhost:9200/sciwiki0/_flush" -H 'Content-Type: application/json'
     # save elasticsearch image (with indexed docs) 
     docker commit indexer dockerimages.fhcrc.org/wiki_elasticsearch:latest
     # clean up

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,11 +41,11 @@ build_test:
     rm -rf tmp && mkdir tmp
     docker cp wiki:/usr/share/nginx/html/ ./tmp/
     docker rm -f wiki
-    docker pull elasticsearch:6.8.23
+    docker pull elasticsearch:8.4.0
     docker network create wiki-indexer || true
     # run an instance of elasticsearch
     docker rm -f elasticsearch || true
-    docker run --network wiki-indexer -d --rm --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" -e "ingest.geoip.downloader.enabled=false"  elasticsearch:6.8.23
+    docker run --network wiki-indexer -d --rm --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" -e "ingest.geoip.downloader.enabled=false"  elasticsearch:8.4.0
     sleep 20
     # create sciwiki0 index
     curl -X PUT "http://localhost:9200/sciwiki0/" -H 'Content-Type: application/json'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ build_test:
     # create sciwiki0 index
     curl -X PUT "http://localhost:9200/sciwiki0/" -H 'Content-Type: application/json'
     # index wiki pages
-    docker build -t indexer -elasticsearch/
+    docker build -t indexer elasticsearch/
     # run indexer script
     docker run --network wiki-indexer -d --rm --name indexer -v $(pwd)/tmp:/html indexer
     # save elasticsearch image (with indexed docs) 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,12 +5,15 @@ before_script:
   
 build_test:
   script: |
+    # put info about this commit/branch into /info.txt
     echo Information > info.txt
     echo "Branch: ${CI_COMMIT_BRANCH}" >> info.txt
     echo "Commit: ${CI_COMMIT_SHA}" >> info.txt
     echo "Commit comment:" >> info.txt
     echo " ${CI_COMMIT_MESSAGE}" >> info.txt
     echo "Build time: $(date)" >> info.txt
+
+    # get markdown pages for easybuild modules
     rm -rf easybuild-life-sciences-main main.zip ./_scicomputing/bio-modules-18.04.md.orig
     # faster than cloning:
     curl -LO https://github.com/FredHutch/easybuild-life-sciences/archive/refs/heads/main.zip
@@ -28,8 +31,34 @@ build_test:
     tail -n +$FIRST_BLANK_LINE ./_scicomputing/bio-modules-18.04.md.orig >> ./_scicomputing/bio-modules-18.04.md
     rm -rf easybuild-life-sciences-main main.zip ./_scicomputing/bio-modules-18.04.md.orig
 
-
+    # build image
     docker build -t dockerimages.fhcrc.org/wiki:latest .
+
+    # build search index
+    # run image and copy HTML files out of it
+    docker run -d --name wiki -p dockerimages.fhcrc.org/wiki:latest
+    rm -rf tmp && mkdir tmp
+    docker cp wiki:/usr/share/nginx/html/ ./tmp/
+    docker rm -f wiki
+    docker pull elasticsearch:8.4.0
+    docker network create wiki-indexer || true
+    # run an instance of elasticsearch
+    docker run --network wiki-indexer -d --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" elasticsearch:8.4.0
+    sleep 20
+    # create sciwiki0 index
+    curl -X PUT "http://localhost:9200/sciwiki0/" -H 'Content-Type: application/json'
+    # index wiki pages
+    docker build -t indexer -elasticsearch/
+    # run indexer script
+    docker run --network wiki-indexer -d --rm --name indexer -v $(pwd)/tmp:/html indexer
+    # save elasticsearch image (with indexed docs) 
+    docker commit indexer dockerimages.fhcrc.org/wiki_elasticsearch:latest
+    # clean up
+    docker rm -f indexer elasticsearch
+    rm -rf tmp
+
+
+
 
 
 # build for every branch EXCEPT main and push to preview site
@@ -46,7 +75,9 @@ deploy_preview:
   script:
     - docker login --username $DOCKERIMAGES_USER --password $DOCKERIMAGES_PASS https://dockerimages.fhcrc.org
     - docker tag dockerimages.fhcrc.org/wiki:latest dockerimages.fhcrc.org/wiki-preview:latest 
+    - docker tag dockerimages.fhcrc.org/wiki_elasticsearch:latest dockerimages.fhcrc.org/wiki_elasticsearch-preview:latest
     - docker push dockerimages.fhcrc.org/wiki-preview:latest
+    - docker push dockerimages.fhcrc.org/wiki_elasticsearch-preview:latest
     - sleep 15
     - rancher-v0.6.2/rancher --url https://ponderosa.fhcrc.org --access-key $PREVIEW_RANCHERAPI_KEY --secret-key $PREVIEW_RANCHERAPI_SECRET up -d --pull --force-upgrade --confirm-upgrade --stack wiki_preview --file docker-compose-preview.yml --rancher-file rancher-compose.yml
 
@@ -59,6 +90,7 @@ deploy:
     refs:
        - main
   script: |
+    # find orphan assets
     rm -f orphans.txt*
     for F in $(find assets/* -type f) ; do grep -r -q $F * || echo "$F"; done > orphans.txt.tmp
     #cat orphans.txt.tmp | fgrep -v "assets/css/" | fgrep -v "assets/js/" > orphans.txt
@@ -90,6 +122,7 @@ deploy:
     fi
     docker login --username $DOCKERIMAGES_USER --password $DOCKERIMAGES_PASS https://dockerimages.fhcrc.org
     docker push dockerimages.fhcrc.org/wiki:latest
+    docker push dockerimages.fhcrc.org/wiki_elasticsearch:latest
     sleep 15
     rancher-v0.6.2/rancher --url https://ponderosa.fhcrc.org --access-key $RANCHERAPI_KEY --secret-key $RANCHERAPI_SECRET up -d --pull --force-upgrade --confirm-upgrade --stack wiki --file docker-compose.yml --rancher-file rancher-compose.yml
   

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ build_test:
 
     # build search index
     # run image and copy HTML files out of it
-    docker run -d --name wiki -p dockerimages.fhcrc.org/wiki:latest
+    docker run -d --rm --name wiki dockerimages.fhcrc.org/wiki:latest
     rm -rf tmp && mkdir tmp
     docker cp wiki:/usr/share/nginx/html/ ./tmp/
     docker rm -f wiki

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,7 @@ before_script:
   
 build_test:
   script: |
+    set -x
     # put info about this commit/branch into /info.txt
     echo Information > info.txt
     echo "Branch: ${CI_COMMIT_BRANCH}" >> info.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ build_test:
     docker pull elasticsearch:8.4.0
     docker network create wiki-indexer || true
     # run an instance of elasticsearch
-    docker rm -f elasticsearch
+    docker rm -f elasticsearch || true
     docker run --network wiki-indexer -d --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" elasticsearch:8.4.0
     sleep 20
     # create sciwiki0 index

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,6 +44,7 @@ build_test:
     docker pull elasticsearch:8.4.0
     docker network create wiki-indexer || true
     # run an instance of elasticsearch
+    docker rm -f elasticsearch
     docker run --network wiki-indexer -d --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" elasticsearch:8.4.0
     sleep 20
     # create sciwiki0 index
@@ -53,7 +54,6 @@ build_test:
     # run indexer script
     docker run --network wiki-indexer -d --rm --name indexer -v $(pwd)/tmp:/html indexer
     # save elasticsearch image (with indexed docs) 
-    docker rm -f elasticsearch
     docker commit indexer dockerimages.fhcrc.org/wiki_elasticsearch:latest
     # clean up
     docker rm -f indexer elasticsearch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,10 +52,10 @@ build_test:
     # index wiki pages
     docker build -t indexer elasticsearch/
     # run indexer script
-    docker run --network wiki-indexer -d --rm --name indexer -v $(pwd)/tmp:/html indexer
+    docker run --network wiki-indexer --rm --name indexer -v $(pwd)/tmp:/html indexer
     curl -X POST "http://localhost:9200/sciwiki0/_flush" -H 'Content-Type: application/json'
     # save elasticsearch image (with indexed docs) 
-    docker commit indexer dockerimages.fhcrc.org/wiki_elasticsearch:latest
+    docker commit elasticsearch dockerimages.fhcrc.org/wiki_elasticsearch:latest
     # clean up
     docker rm -f indexer elasticsearch
     rm -rf tmp

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ build_test:
     docker network create wiki-indexer || true
     # run an instance of elasticsearch
     docker rm -f elasticsearch || true
-    docker run --network wiki-indexer -d --rm --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" elasticsearch:6.8.23
+    docker run --network wiki-indexer -d --rm --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" -e "ingest.geoip.downloader.enabled=false"  elasticsearch:6.8.23
     sleep 20
     # create sciwiki0 index
     curl -X PUT "http://localhost:9200/sciwiki0/" -H 'Content-Type: application/json'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,7 @@ build_test:
     # run indexer script
     docker run --network wiki-indexer -d --rm --name indexer -v $(pwd)/tmp:/html indexer
     # save elasticsearch image (with indexed docs) 
+    docker rm -f elasticsearch
     docker commit indexer dockerimages.fhcrc.org/wiki_elasticsearch:latest
     # clean up
     docker rm -f indexer elasticsearch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ build_test:
     # save elasticsearch image (with indexed docs) 
     docker commit elasticsearch dockerimages.fhcrc.org/wiki_elasticsearch:latest
     # clean up
-    docker rm -f indexer elasticsearch
+    docker rm -f elasticsearch
     rm -rf tmp
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,5 +47,5 @@ COPY --from=0 /srv/jekyll/_site/ /usr/share/nginx/html
 RUN cp /usr/share/nginx/html/images/favicon.ico /usr/share/nginx/html/
 COPY ./info.txt /usr/share/nginx/html/
 
-
+COPY  ./default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -280,8 +280,6 @@ This functionality is possible by using the [jekyll-glossary_tooltip](https://gi
 
 Note that this plugin is *not* one of the plugins approved by GitHub to be used with GitHub Pages, so this site is no longer hosted by Pages. Instead we build it ourselves using our CI/CD pipeline.
 
-**Coming Soon**: Functionality that will automatically "glossarize" the first occurrence in any Markdown file of terms that are in the glossary. This will be documented here when it is ready.
-
 ## For Admins (everyone else, please do not edit these as your edits will be ignored/removed)
 
 ### Pages that run Demo and Contributors Collection pages:

--- a/_config.yml
+++ b/_config.yml
@@ -261,6 +261,18 @@ defaults:
 
 exclude:
   - ".gitignore"
+  - ".gitlab-ci.yml"
+  - "elasticsearch"
+  - "tmp"
+  - "*.py"
+  - "*.yml"
+  - "Rakefile"
+  - "*.gz"
+  - "rancher-v0.6.2"
+  - "*.sh"
+  - "Dockerfile"
+  - "Gemfile*"
+
 
 #
 tag_archive:

--- a/assets/js/customsearch.js
+++ b/assets/js/customsearch.js
@@ -1,6 +1,6 @@
 
 handleSearchQuery = function (query) {
-    var url = "https://search-sciwiki-search-0-f7ntx2mpc5g6yohp6dtiwzsdiy.us-west-2.es.amazonaws.com/sciwiki0/_search";
+    var url = "/sciwiki0/_search/";
 
     var data = {
         _source: ['title'],

--- a/assets/js/customsearch.js
+++ b/assets/js/customsearch.js
@@ -24,7 +24,7 @@ handleSearchQuery = function (query) {
         } else {
             // TODO if we got more than 100 results we should indicate that we are only showing the 1st 100
             // is pagination worth it?
-            var hitsFound = data['hits']['total'];
+            var hitsFound = data['hits']['total']['value'];
             var hitsPerPage = data['hits']['hits'].length;
             var html = "";
             html += "<span>Found " + hitsFound + " matches for '" + query + "'.</span><br/>\n";

--- a/default.conf
+++ b/default.conf
@@ -15,6 +15,10 @@ server {
     # No other Elasticsearch functionality is exposed so 
     # site users cannot modify the search index, etc. 
     location /sciwiki0/_search/ {
+        add_header Allow "GET, POST" always;
+        if ( $request_method !~ ^(GET|POST)$ ) {
+     	     return 405;
+        }
         proxy_pass http://elasticsearch:9200;
     }
 

--- a/default.conf
+++ b/default.conf
@@ -15,8 +15,8 @@ server {
     # No other Elasticsearch functionality is exposed so 
     # site users cannot modify the search index, etc. 
     location /sciwiki0/_search/ {
-        add_header Allow "GET, POST" always;
-        if ( $request_method !~ ^(GET|POST)$ ) {
+        add_header Allow "HEAD, GET, POST" always;
+        if ( $request_method !~ ^(HEAD|GET|POST)$ ) {
      	     return 405;
         }
         proxy_pass http://elasticsearch:9200;

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,53 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+
+    # Search engine. Any URL starting with /sciwiki0/search
+    # will be handled by the Elasticsearch container. 
+    # No other Elasticsearch functionality is exposed so 
+    # site users cannot modify the search index, etc. 
+    location /sciwiki0/_search/ {
+        proxy_pass http://elasticsearch:9200;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}
+

--- a/docker-compose-preview.yml
+++ b/docker-compose-preview.yml
@@ -12,5 +12,6 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
       - ingest.geoip.downloader.enabled=false
+      - ES_JAVA_OPTS="-Xms512m -Xmx512m"
     labels:
       io.rancher.container.pull_image: always

--- a/docker-compose-preview.yml
+++ b/docker-compose-preview.yml
@@ -11,5 +11,6 @@ services:
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
+      - ingest.geoip.downloader.enabled=false
     labels:
       io.rancher.container.pull_image: always

--- a/docker-compose-preview.yml
+++ b/docker-compose-preview.yml
@@ -3,8 +3,6 @@ services:
   wiki:
     image: dockerimages.fhcrc.org/wiki-preview:latest
     stdin_open: true
-    ports:
-      - "80:80"
     labels:
       io.rancher.container.pull_image: always
   elasticsearch:

--- a/docker-compose-preview.yml
+++ b/docker-compose-preview.yml
@@ -4,6 +4,14 @@ services:
     image: dockerimages.fhcrc.org/wiki-preview:latest
     stdin_open: true
     ports:
-      - "80"
+      - "80:80"
+    labels:
+      io.rancher.container.pull_image: always
+  elasticsearch:
+    image: dockerimages.fhcrc.org/wiki_elasticsearch-preview:latest
+    stdin_open: true
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
     labels:
       io.rancher.container.pull_image: always

--- a/docker-compose-preview.yml
+++ b/docker-compose-preview.yml
@@ -12,6 +12,6 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
       - ingest.geoip.downloader.enabled=false
-      - ES_JAVA_OPTS="-Xms512m -Xmx512m"
+      - JAVA_OPTS="-Xms512m -Xmx512m"
     labels:
       io.rancher.container.pull_image: always

--- a/docker-compose-preview.yml
+++ b/docker-compose-preview.yml
@@ -12,6 +12,6 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
       - ingest.geoip.downloader.enabled=false
-      - JAVA_OPTS="-Xms512m -Xmx512m"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     labels:
       io.rancher.container.pull_image: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,6 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
       - ingest.geoip.downloader.enabled=false
+      - ES_JAVA_OPTS="-Xms512m -Xmx512m"
     labels:
       io.rancher.container.pull_image: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,6 @@ services:
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
+      - ingest.geoip.downloader.enabled=false
     labels:
       io.rancher.container.pull_image: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,6 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
       - ingest.geoip.downloader.enabled=false
-      - ES_JAVA_OPTS="-Xms512m -Xmx512m"
+      - JAVA_OPTS="-Xms512m -Xmx512m"
     labels:
       io.rancher.container.pull_image: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,14 @@ services:
     image: dockerimages.fhcrc.org/wiki:latest
     stdin_open: true
     ports:
-      - "80"
+      - "80:80"
+    labels:
+      io.rancher.container.pull_image: always
+  elasticsearch:
+    image: dockerimages.fhcrc.org/wiki_elasticsearch:latest
+    stdin_open: true
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
     labels:
       io.rancher.container.pull_image: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,6 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
       - ingest.geoip.downloader.enabled=false
-      - JAVA_OPTS="-Xms512m -Xmx512m"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     labels:
       io.rancher.container.pull_image: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ services:
   wiki:
     image: dockerimages.fhcrc.org/wiki:latest
     stdin_open: true
-    ports:
-      - "80:80"
     labels:
       io.rancher.container.pull_image: always
   elasticsearch:

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 RUN apt-get update -y && apt-get install -y python3 python3-pip pandoc curl
 

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 RUN apt-get update -y && apt-get install -y python3 python3-pip pandoc curl
 
 # not 6.8.2 8.4.0
-RUN pip3 install elasticsearch==6.8.2 sh ipython beautifulsoup4 requests
+RUN pip3 install elasticsearch==8.4.0 sh ipython beautifulsoup4 requests
 
 COPY indexer.py /
 

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:22.04
+
+RUN apt-get update -y && apt-get install -y python3 python3-pip pandoc curl
+
+# not 6.8.2
+RUN pip3 install elasticsearch==8.4.0 sh ipython beautifulsoup4 requests
+
+COPY indexer.py /
+
+WORKDIR /
+
+CMD ["python3", "indexer.py"]
+
+
+

--- a/elasticsearch/indexer.py
+++ b/elasticsearch/indexer.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+# library imports
+
+import json
+import os
+import sys
+
+# third party imports
+
+from bs4 import BeautifulSoup
+import requests
+import sh
+
+INDEX_NAME="sciwiki0"
+
+from elasticsearch.helpers import bulk
+# old:
+#from elasticsearch import Elasticsearch, RequestsHttpConnection, ElasticsearchException
+# new:
+from elasticsearch import Elasticsearch, ApiError
+
+def crawl_documents():
+    docs = []
+    for root, dirs, files in os.walk('/html/html'):
+        for file in files:
+            if file.endswith("index.html"):
+                fullpath = os.path.join(root, file)
+                url = fullpath.replace('/html/html', '')
+                url = url.replace("index.html", "")
+                print(f"Processing {url} ...")
+                ret = sh.pandoc("-f", "html", "-t", "plain", fullpath)
+                text = ret.stdout.decode('utf-8')
+                with open(fullpath) as f:
+                    soup = BeautifulSoup(f, "html.parser")
+                title = soup.title.string
+                title = title.replace(" - Fred Hutch Biomedical Data Science Wiki", "").strip()
+                doc = dict(url=url, content=text, title=title)
+                docs.append(doc)
+    return docs
+
+
+def wrap(docs):
+    outer = []
+    for doc in docs:
+        doc_id = doc['url']
+        del doc['url']
+        item = dict(_index=INDEX_NAME, _id=doc_id, _source=doc)
+        outer.append(item)
+    return outer
+
+def bulk_up(docs):
+    client = Elasticsearch("http://elasticsearch:9200",
+      headers={'Content-Type': 'application/json'})
+    print("Preparing for bulk import....")
+    try:
+        retval = bulk(client, docs)
+        print("Bulk import was successful.")
+        print(retval)
+        return retval
+    except ApiError as e:
+        print("Bulk import failed.")
+        print(e)
+        sys.exit(1)
+
+def main():
+    docs = wrap(crawl_documents())
+    bulk_up(docs)
+
+if __name__ == '__main__':
+    main()

--- a/elasticsearch/indexer.py
+++ b/elasticsearch/indexer.py
@@ -16,9 +16,9 @@ INDEX_NAME="sciwiki0"
 
 from elasticsearch.helpers import bulk
 # old:
-from elasticsearch import Elasticsearch, RequestsHttpConnection, ElasticsearchException
+# from elasticsearch import Elasticsearch, RequestsHttpConnection, ElasticsearchException
 # new:
-# from elasticsearch import Elasticsearch, ApiError
+from elasticsearch import Elasticsearch, ApiError
 
 def crawl_documents():
     docs = []
@@ -46,8 +46,8 @@ def wrap(docs):
         doc_id = doc['url']
         del doc['url']
         # old version requires type, new version doesn't want it.
-        doc['_type'] = 'document' # old
-        item = dict(_index=INDEX_NAME, _id=doc_id, type="document", _source=doc)
+        # doc['_type'] = 'document' # old
+        item = dict(_index=INDEX_NAME, _id=doc_id, _source=doc)
         outer.append(item)
     return outer
 
@@ -61,9 +61,9 @@ def bulk_up(docs):
         print(retval)
         return retval
     # new:
-    # except ApiError as e:
+    except ApiError as e:
     # old:
-    except ElasticsearchException as e:
+    # except ElasticsearchException as e:
         print("Bulk import failed.")
         print(e)
         sys.exit(1)


### PR DESCRIPTION
This PR changes the way the site search works. Currently search queries go to an AWS Elasticsearch cluster in the old SciComp AWS account.

That account is going to be decommissioned soon. 

I looked at migrating this Elasticsearch cluster to the new SciComp AWS account and I ran into some problems. I may continue to investigate those problems, but along the way I had the idea that, now that we are hosting the wiki in our CI/CD platform (not GitHub pages), it would be possible to host our own single-node Elasticsearch cluster in a container that runs along with the wiki container. So that's what this is.

So in this PR, the indexing of the site is part of the site building process. It's not done anymore by an AWS Lambda function (that lambda function will need to be decommissioned, but the AWS account is going away anyway). 

The nginx configuration of the wiki container was modified slightly, to proxy requests to the Elasticsearch container. Only requests that start with `/sciwiki0/_search` are proxied (`sciwiki0` is the name of the ES index and `_search` is the endpoint for searching). This means no other endpoints can be accessed from the outside. This prevents users from doing anything with our ES cluster except searching it (for additional security, only GET and POST requests are proxied to ES). It also means we don't have to worry about CORS at all because all requests are going to the same host/port. And we don't have to pay for the ES cluster in AWS anymore.

Note that when you push to a branch other than `main`, the search index is built and available at 
https://sciwiki-preview.fredhutch.org (inside the FH network). This is separate from the index on the production site. 
So if you make a branch with a page that has to do with peaches, you can search for peaches in https://sciwiki-preview.fredhutch.org and the appropriate results will show up. When you merge your branch into `main`, then the same search will work on production.

One slight change is that I've changed the way pages are indexed. The current way is that a crawler (running inside a Lambda function) actually makes http requests, starting with the index page, and follows links until it has hit every page. 
Since the new method runs in our CI/CD pipeline, we actually have access to the freshly created pages, so we just open them as files on the filesystem. This is faster and avoids all the web traffic associated with crawling the site.
One slight downside is that we may end up indexing orphan pages (pages which don't have any links to them), since we are just indexing all `index.html` files, and not following links. 

I don't think we have a lot of orphan pages but I'll open an issue to track this and come up with a solution. I think there are some tools in the Jekyll ecosystem to handle this. A quick search shows that there is a [GitHub action](https://github.com/MOLOCH-dev/jekyll-orphan-pages-action/blob/main/action.yml) to do this that could easily be ported to run in GitLab or just as a cron job.

If you merge this PR, please choose the option to squash commits if it is possible (it may not be, because somehow a merge happened at some point). This ended up being very fiddly and there are tons of silly commits.

