### PR TITLE
Correct links in pathways

### DIFF
--- a/_pathways/path-batch-computing.md
+++ b/_pathways/path-batch-computing.md
@@ -26,7 +26,7 @@ If you are unfamiliar with any of these terms, hover over them to find more info
 ### Get a Hutchnet ID
 In order to use Fred Hutch batch computing resources you must have valid Fred Hutch credentials.  Sepcicially a [HutchNet ID](/scicomputing/access_credentials/#hutchnet-id).
 
-This HutchNet ID needs to be associated with a [PI account](scicomputing/access_credentials/#accessing-slurm-clusters) in order to submit jobs. 
+This HutchNet ID needs to be associated with a [PI account](/scicomputing/access_credentials/#accessing-slurm-clusters) in order to submit jobs. 
 
 
 ### Connect to the Campus Network
@@ -42,11 +42,11 @@ A terminal provides a text-based interface to computers (the "command line").
 
 Macintosh OSX has a built in terminal application. It can be found in _Applications->Utilities->Terminal_.  Other options are available that are more full featured such as [iterm2](https://iterm2.com/), which is one free option (please consider [donating](https://iterm2.com/donate.html)!)
 
-Windows has a few different terminals built in, but many of these are unsuitable for accessing Linux systems.  Two easy options are the Microsoft Terminal app (available in the App Store) and [PuTTY](scicomputing/access_methods/#windows).
+Windows has a few different terminals built in, but many of these are unsuitable for accessing Linux systems.  Two easy options are the Microsoft Terminal app (available in the App Store) and [PuTTY](/scicomputing/access_methods/#windows).
 
 ### Shell Connections to the 'rhino' Login Nodes
 
-Once you have a connection to the Hutch network and a suitable terminal, the next step is to [connect to the login nodes known as `rhino`.](scicomputing/access_methods/#ssh-connections)
+Once you have a connection to the Hutch network and a suitable terminal, the next step is to [connect to the login nodes known as `rhino`.](/scicomputing/access_methods/#ssh-connections)
 
 ### Home Directory
 
@@ -57,12 +57,12 @@ If you get an error like `Home directory not found` when you log in, please emai
 
 ### Navigating the Compute Environment
 
-The [common storage options](scicomputing/store_posix.md) are available in the `rhino`-`gizmo` compute environment. These paths are available in the same location on each of these hosts.
+The [common storage options](/scicomputing/store_posix.md) are available in the `rhino`-`gizmo` compute environment. These paths are available in the same location on each of these hosts.
 
 You'll be started (by default) with a bash shell and most of the common [GNU/Linux utilities](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/index.html)
 
 ### Familiarize Yourself with SLURM
-SLURM is the workload manager for our `gizmo` computing cluster.  Review the documentation for basic information about how [SLURM works](scicomputing/compute_jobs/#basic-slurm-terminology).  Once you have logged into the login nodes (`rhino`), you will be sending non-interactive instructions to the compute nodes (`gizmo`) via these instructions.  
+SLURM is the workload manager for our `gizmo` computing cluster.  Review the documentation for basic information about how [SLURM works](/scicomputing/compute_jobs/#basic-slurm-terminology).  Once you have logged into the login nodes (`rhino`), you will be sending non-interactive instructions to the compute nodes (`gizmo`) via these instructions.
 
 ### Create a Script
 
@@ -73,13 +73,13 @@ wget https://github.com/FredHutch/slurm-examples/blob/master/introduction/1-hell
 
 ### Submit the Script
 
-Use the [sbatch command](scicomputing/compute_jobs/#submitting-jobs) to submit the script to `gizmo`.  Output should appear in the form of a log file in the current driectory with the jobID in the filename.  
+Use the [sbatch command](/scicomputing/compute_jobs/#submitting-jobs) to submit the script to `gizmo`.  Output should appear in the form of a log file in the current driectory with the jobID in the filename.
 
 ## Where to go from here
 
 ### Managing Jobs
 
-[This documentation](scicomputing/compute_jobs/#managing-jobs) provides more information on managing jobs that are queued and running on the cluster, including steps to take when jobs don't run.
+[This documentation](/scicomputing/compute_jobs/#managing-jobs) provides more information on managing jobs that are queued and running on the cluster, including steps to take when jobs don't run.
 
 ### Writing More Complicated Scripts
 
@@ -93,5 +93,4 @@ This was a simple script - you'll need more advanced scripts to run workload on 
 We've described a single job - when your work requires many jobs or many steps, more advanced tools are necessary, and you begin to delve into [parallel computing](/scicomputing/compute_parallel/).  Two commonly used approaches at the Fred Hutch include:
 
  - SLURM job arrays provide an easy mechanism for submitting thousands of homogenous jobs
- - [Workflow managers](/scicomputing/compute_parallel/#workflow-managers) are the gold-standard for managing computational workflows, particularly valuable for managing multi-step analyses.  [Cromwell](/compdemos/Cromwell/) and [Nextflow](/compdemos/nextflow/) are the two preferred workflow manager tools at the Hutch.  
-
+ - [Workflow managers](/scicomputing/compute_parallel/#workflow-managers) are the gold-standard for managing computational workflows, particularly valuable for managing multi-step analyses.  [Cromwell](/compdemos/Cromwell/) and [Nextflow](/compdemos/nextflow/) are the two preferred workflow manager tools at the Hutch.


### PR DESCRIPTION
 - missing "/" at the beginning of the target URL, made links relative
 to this page
 - see issue #787