### PR TITLE
Update main.scss

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -33,3 +33,8 @@ html {
         font-size: 18px; // originally 22px
     }
 }
+
+/* Format inline code blocks */
+code.language-plaintext.highlighter-rouge {
+  background: #afb8c133; // originally #fafafa
+}


### PR DESCRIPTION
CSS change to format inline code blocks with a darker background (matches what github uses) to make them easier to see. I tested this locally.

Resolves: #804