### PR TITLE
Update social-share.html

### DIFF
--- a/_includes/social-share.html
+++ b/_includes/social-share.html
@@ -7,7 +7,7 @@
           {% endif %}
           {%- endfor %}
   
-  <a href="{{site.github.repository_url}}/blob/master/{{page.relative_path}}"><i class="fas fa-pen-square"></i>
+  <a href="{{site.github.repository_url}}/blob/main/{{page.relative_path}}"><i class="fas fa-pen-square"></i>
   <span> Edit this Page via GitHub</span></a> &nbsp; &nbsp; &nbsp;
   <a href="{{site.github.repository_url}}/issues"><i class="far fa-comment-dots"></i><span> Comment by Filing an Issue</span></a>&nbsp; &nbsp; &nbsp;
   <a href="https://fhdata.slack.com/#question-and-answer"><i class="fas fa-question-circle"></i>


### PR DESCRIPTION
Change repository url to main in template. With this change, all pages now link to main instead of master. I tested this change locally.

Resolves: #808