### PR TITLE
Remove version pin for faraday

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :development, :test do
   gem 'jemoji', '~> 0.12.0'
   gem 'html-proofer', '~> 4.2.0'
   gem 'rake', '~> 13.0.6'
-  gem 'faraday', '~> 2.3.0'
+  gem 'faraday'
   gem 'webrick', '~> 1.7.0'
 end
 


### PR DESCRIPTION
Resolves issue #828 .  I'm not sure if a version pin for this is required- dependencies seem to resolve OK and I can build and serve with bundle exec, so it seems to work OK