### PR TITLE
remove jekyll-gist dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ group :development, :test do
   gem "nokogiri", '~> 1.13.7'
   gem 'jekyll-toc', '~> 0.17.1'
   gem 'jekyll-include-cache', '~> 0.2.1'
-  gem 'jekyll-gist', '~> 1.5.0'
   gem 'jekyll-remote-theme', '~> 0.4.3'
   gem 'jemoji', '~> 0.12.0'
   gem 'html-proofer', '~> 4.2.0'


### PR DESCRIPTION
Closes #828 in a different way.

I prefer not to have unpinned versions in the Gemfile so that the site is not broken by incoming (e,g. major version) changes.

I looked at the package at the top (bottom?) of the dependency tree that ultimately required an earlier version of faraday - jekyll-gist. It appears we do not actually use that package.

So I just took out the requirement of it in the Gemfile and the site appears to build and deploy just fine.
