### PR TITLE
Clarify information about filesystem access permissions

### DIFF
--- a/_scicomputing/access_permissions.md
+++ b/_scicomputing/access_permissions.md
@@ -20,22 +20,45 @@ Group
 Local data storage permissions are organized typically by PI, such as in `fast` where a PI folder would have the name `lastname_f`.  Each PI has a group of members, typically those direct reports or other members who have been manually added due to requests as part of collaborations.  Folders within the PI folder can then have more limited access to sub-groups or even to the level of a single individual.
 
 #### Collaborating with other labs
+
 Members of other labs can be added to a lab's group or a subgroup to allow those individuals access to shared file locations. When requesting a user be added, please email `scicomp` with your request and include the following information:
+
 - Hutch ID of the user to be given access
 - The most restricted path to the folder where permissions need to be given
 - Whether the user should be given read-only permissions or if they need read and write permissions
 - CC the PI or manager associated with the data storage location to ensure communication
 
-#### Shared Subfolders
-Sometimes you can have access to a lower level folder, but do not have access (execute permissions) to a parent directory so for mapped drives on a local computer, you may not be able to map a directory and then click through subfolders to get to the folder you think you have access to.  Before emailing for assistance, test to see if you can directly access the folder containing the data in case this issue is preventing your access.
+#### Cross Lab Collaboration Subfolders
 
-- Command Line
-Try to `cd /path/to/your/data` directly rather than `cd /path/` and then changing directories to subfolders. Sometimes changing directories directly to the lowest directory to which you should have permissions.
+Sometimes you can have access to a folder but not access to the folders that contain this folder. This will manifest as "permission denied" when you try to access those parent folders, either via `cd` from a shell session or if you browse through `smb://center/fh/fast`.  These parent directories are "blind", meaning you can pass through, but you cannot read or see any of the files or directories in that parent directory.
 
-- Desktop 
-map (make a shortcut) to a child directory directly even if you can't map to a parent directory.  Sometimes connecting directly to the path will work when connecting to a parent directory will not. 
+If you have been told you have access to a folder but encounter a "permission denied" error when browsing through to the directory it will be necessary to specify the full path to the folder.
+
+##### At the Command Line
+
+For this example, let's assume you have been given access to the path `/fh/fast/pi_a/collaboration`.  You don't have access to `/fh/fast/pi_a` so the command `ls /fh/fast/pi_a`  fails:
+
+```
+rhino03[~]: ls -l /fh/fast/pi_a
+ls: cannot open directory '/fh/fast/pi_a': Permission denied
+```
+
+Similarly, tab-completion will not return anything for that path.  In this circumstance you will need to use the full path to the shared directory:
+
+```
+rhino03[~]: ls -l /fh/fast/pi_a/collaboration
+drwxrws---   4 api    pi_a_grp           65 Dec  4 17:20 archive
+drwxrws---  11 api    pi_a_grp          282 Dec 15 10:12 data
+```
+
+##### Desktop Mounts
+
+For this example, let's assume you have been given access to the path `/fh/fast/pi_a/collaboration` which you would like to mount onto your Windows or Macintosh workstation.
+
+Using the UNC path `smb://center.fhcrc.org/fh/` to then attempt to browse (or click) through to the path will result in a "Permission denied" error when you reach the PI directory (i.e. when you reach `smb://center.fhcrc.org/fh/fast/pi_a`).  In this case what you will need to do is specify the full path, either in the mount command or in the address bar of Windows explorer.  The path you would need to enter there would be something like `smb://center.fhcrc.org/fh/fast/pi_a/collaboration`.
 
 #### Requesting Changes to Permissions
+
 If you do not seem to have correct permissions to folder or stoarage location and have tested the above connection instructions, email `scicomp` the following information:
 
 - The most restricted path to the folder where permissions are needed

--- a/_scicomputing/access_permissions.md
+++ b/_scicomputing/access_permissions.md
@@ -64,23 +64,3 @@ If you do not seem to have correct permissions to the folder and have tested the
 
 > IMPORTANT: Please CC the PI or manager associated for this location with your request to `scicomp`
 
-### Cloud Based Storage
-
-Cloud storage is provided by default in PI accounts.  Please see the [S3 resources](/compdemos/aws-s3/) and the [FAQ](/compdemos/cloud-faq/) for more information.
-
-#### User permissions
-
-All users by default have the following permissions in all buckets except for prefixes that are restricted.
-
-- List
-- Read
-- Write
-
-Data Managers and Admins have all permissions on all folders within their accounts' S3 buckets.
-
-#### Restricted S3 prefixes (folders)
-
-- `readonly/`
-- `SR/`
-
-The `SR/` prefix is typically used by any Data Cores within Shared Resources to deliver data into your account.  The `readonly/` folder can be useful if you have certain data that you do not want the users in your lab to be able to alter.

--- a/_scicomputing/access_permissions.md
+++ b/_scicomputing/access_permissions.md
@@ -6,29 +6,27 @@ primary_reviewers:
 
 ## Overview of Permissions
 
-### Local Filesystems
+### Permissions on the Fast Filesystem
 
-#### Types of permissions and users
-Read
-Write
-Execute
+#### Permissions and Roles
 
-User 
-Group
+Permissions on the fast file system are controlled using UNIX traditional access control lists (ACLs).  These ACLs provide access controls based on your role and what activities your role is allowed.
 
+For the purpose of determining your access to a directory of file, you will have the role of "user" (the owner of the file), "group", or "other" (for everyone else).  For each of those roles you can have one or more of read, write, and execute activities allowed.  The operating system will look at your login and use that to first determine which of those roles you have.  Once the OS has determined your role, it will look at the activities allowed for that role when accessing the directory or file and compare that to the activity you wish to perform.  Based on that, you will either be allowed or denied the desired access.
 
-Local data storage permissions are organized typically by PI, such as in `fast` where a PI folder would have the name `lastname_f`.  Each PI has a group of members, typically those direct reports or other members who have been manually added due to requests as part of collaborations.  Folders within the PI folder can then have more limited access to sub-groups or even to the level of a single individual.
+Fast file data storage permissions are organized by PI: a PI folder would have the name `lastname_f`.  Each PI has a default group, typically (though not exclusively) lab members.  Within the PI folder there can be folders that have different ACLs, allowing for collaborations and other activities requiring access from others outside the PI's lab.
 
-#### Collaborating with other labs
+#### Collaboration Folder Permissions
 
-Members of other labs can be added to a lab's group or a subgroup to allow those individuals access to shared file locations. When requesting a user be added, please email `scicomp` with your request and include the following information:
+A collaboration folder is set up to allow members of other labs access. In most cases, a bespoke group will be set up that includes the lab members and the members of those other labs.  Email `scicomp` to get this set up- include the following information:
 
-- Hutch ID of the user to be given access
-- The most restricted path to the folder where permissions need to be given
-- Whether the user should be given read-only permissions or if they need read and write permissions
-- CC the PI or manager associated with the data storage location to ensure communication
+- The Hutchnet ID of the user(s) to be given access
+- The path to a folder where collaboration data will be stored
+- Whether you need read-only permissions or read and write permissions for members of the group
 
-#### Cross Lab Collaboration Subfolders
+> IMPORTANT: Please CC the PI or manager associated for this location with your request to `scicomp`
+
+#### Accessing Collaboration Folders
 
 Sometimes you can have access to a folder but not access to the folders that contain this folder. This will manifest as "permission denied" when you try to access those parent folders, either via `cd` from a shell session or if you browse through `smb://center/fh/fast`.  These parent directories are "blind", meaning you can pass through, but you cannot read or see any of the files or directories in that parent directory.
 

--- a/_scicomputing/access_permissions.md
+++ b/_scicomputing/access_permissions.md
@@ -17,7 +17,7 @@ User
 Group
 
 
-Local data storage permissions are organized typically by PI, such as in `fast` where a PI folder would have the name `lastname_f`.  Each PI has a group of members, typically those direct reports or other members who have been manually added due to requests as part of collaborations.  Folders within the PI folder can then have more limited access to sub-groups or even to the level of a single individual.  
+Local data storage permissions are organized typically by PI, such as in `fast` where a PI folder would have the name `lastname_f`.  Each PI has a group of members, typically those direct reports or other members who have been manually added due to requests as part of collaborations.  Folders within the PI folder can then have more limited access to sub-groups or even to the level of a single individual.
 
 #### Collaborating with other labs
 Members of other labs can be added to a lab's group or a subgroup to allow those individuals access to shared file locations. When requesting a user be added, please email `scicomp` with your request and include the following information:
@@ -27,10 +27,10 @@ Members of other labs can be added to a lab's group or a subgroup to allow those
 - CC the PI or manager associated with the data storage location to ensure communication
 
 #### Shared Subfolders
-Sometimes you can have access to a lower level folder, but do not have access (execute permissions) to a parent directory so for mapped drives on a local computer, you may not be able to map a directory and then click through subfolders to get to the folder you think you have access to.  Before emailing for assistance, test to see if you can directly access the folder containing the data in case this issue is preventing your access.  
+Sometimes you can have access to a lower level folder, but do not have access (execute permissions) to a parent directory so for mapped drives on a local computer, you may not be able to map a directory and then click through subfolders to get to the folder you think you have access to.  Before emailing for assistance, test to see if you can directly access the folder containing the data in case this issue is preventing your access.
 
 - Command Line
-Try to `cd /path/to/your/data` directly rather than `cd /path/` and then changing directories to subfolders. Sometimes changing directories directly to the lowest directory to which you should have permissions.  
+Try to `cd /path/to/your/data` directly rather than `cd /path/` and then changing directories to subfolders. Sometimes changing directories directly to the lowest directory to which you should have permissions.
 
 - Desktop 
 map (make a shortcut) to a child directory directly even if you can't map to a parent directory.  Sometimes connecting directly to the path will work when connecting to a parent directory will not. 

--- a/_scicomputing/access_permissions.md
+++ b/_scicomputing/access_permissions.md
@@ -59,11 +59,12 @@ Using the UNC path `smb://center.fhcrc.org/fh/` to then attempt to browse (or cl
 
 #### Requesting Changes to Permissions
 
-If you do not seem to have correct permissions to folder or stoarage location and have tested the above connection instructions, email `scicomp` the following information:
+If you do not seem to have correct permissions to the folder and have tested the above connection instructions, email `scicomp` the following information:
 
-- The most restricted path to the folder where permissions are needed
+- The path to the folder you are attempting to access
 - Whether you need read-only permissions or read and write permissions
-- CC the PI or manager associated with the data storage location to ensure communication
+
+> IMPORTANT: Please CC the PI or manager associated for this location with your request to `scicomp`
 
 ### Cloud Based Storage
 

--- a/_scicomputing/access_permissions.md
+++ b/_scicomputing/access_permissions.md
@@ -8,15 +8,13 @@ primary_reviewers:
 
 ### Permissions on the Fast Filesystem
 
-#### Permissions and Roles
-
 Permissions on the fast file system are controlled using UNIX traditional access control lists (ACLs).  These ACLs provide access controls based on your role and what activities your role is allowed.
 
 For the purpose of determining your access to a directory of file, you will have the role of "user" (the owner of the file), "group", or "other" (for everyone else).  For each of those roles you can have one or more of read, write, and execute activities allowed.  The operating system will look at your login and use that to first determine which of those roles you have.  Once the OS has determined your role, it will look at the activities allowed for that role when accessing the directory or file and compare that to the activity you wish to perform.  Based on that, you will either be allowed or denied the desired access.
 
 Fast file data storage permissions are organized by PI: a PI folder would have the name `lastname_f`.  Each PI has a default group, typically (though not exclusively) lab members.  Within the PI folder there can be folders that have different ACLs, allowing for collaborations and other activities requiring access from others outside the PI's lab.
 
-#### Collaboration Folder Permissions
+### Collaboration Folder Permissions
 
 A collaboration folder is set up to allow members of other labs access. In most cases, a bespoke group will be set up that includes the lab members and the members of those other labs.  Email `scicomp` to get this set up- include the following information:
 
@@ -26,13 +24,13 @@ A collaboration folder is set up to allow members of other labs access. In most 
 
 > IMPORTANT: Please CC the PI or manager associated for this location with your request to `scicomp`
 
-#### Accessing Collaboration Folders
+### Accessing Collaboration Folders
 
 Sometimes you can have access to a folder but not access to the folders that contain this folder. This will manifest as "permission denied" when you try to access those parent folders, either via `cd` from a shell session or if you browse through `smb://center/fh/fast`.  These parent directories are "blind", meaning you can pass through, but you cannot read or see any of the files or directories in that parent directory.
 
 If you have been told you have access to a folder but encounter a "permission denied" error when browsing through to the directory it will be necessary to specify the full path to the folder.
 
-##### At the Command Line
+#### At the Command Line
 
 For this example, let's assume you have been given access to the path `/fh/fast/pi_a/collaboration`.  You don't have access to `/fh/fast/pi_a` so the command `ls /fh/fast/pi_a`  fails:
 
@@ -49,13 +47,13 @@ drwxrws---   4 api    pi_a_grp           65 Dec  4 17:20 archive
 drwxrws---  11 api    pi_a_grp          282 Dec 15 10:12 data
 ```
 
-##### Desktop Mounts
+#### Desktop Mounts
 
 For this example, let's assume you have been given access to the path `/fh/fast/pi_a/collaboration` which you would like to mount onto your Windows or Macintosh workstation.
 
 Using the UNC path `smb://center.fhcrc.org/fh/` to then attempt to browse (or click) through to the path will result in a "Permission denied" error when you reach the PI directory (i.e. when you reach `smb://center.fhcrc.org/fh/fast/pi_a`).  In this case what you will need to do is specify the full path, either in the mount command or in the address bar of Windows explorer.  The path you would need to enter there would be something like `smb://center.fhcrc.org/fh/fast/pi_a/collaboration`.
 
-#### Requesting Changes to Permissions
+#### Getting Help
 
 If you do not seem to have correct permissions to the folder and have tested the above connection instructions, email `scicomp` the following information:
 


### PR DESCRIPTION
There was an incomplete discussion of file system permissions- this has been expanded slightly with the scope reduced to just fast-file.  The S3 access permissions information was obsolete and removed.

This includes information on collaboration directories and navigating blind parent directories