### PR TITLE
ignore failure from docker rm

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,7 +76,7 @@ create_search_index_0:
     docker run -d --rm --name $CONTAINER_NAME sc-registry.fredhutch.org/wiki:test
     rm -rf elasticsearch/tmp && mkdir elasticsearch/tmp
     docker cp $CONTAINER_NAME:/usr/share/nginx/html/ ./elasticsearch/tmp/
-    docker rm -f $CONTAINER_NAME
+    docker rm -f $CONTAINER_NAME || true
     echo fultr
     ls -l elasticsearch
     ls -l elasticsearch/tmp


### PR DESCRIPTION
This should (hopefully) fix some issues with the wiki occasionally failing to build.
