### PR TITLE
Update GPU options for slurm commands

### DIFF
--- a/_compdemos/tensorflow-gpu.md
+++ b/_compdemos/tensorflow-gpu.md
@@ -30,11 +30,11 @@ then create a small python test script:
     chmod +x ~/tf-test.py
 ```
 
-and run it on Gizmo with `--gres=gpu` to select a node with GPU:
+and run it on Gizmo with `--gpus=1` to select a node with GPU:
 
 
 ``` 
-    ~$ sbatch -o out.txt --gres=gpu ~/tf-test.py
+    ~$ sbatch -o out.txt --gpus=1 ~/tf-test.py
     ~$ tail -f out.txt
 ```
 

--- a/_scicomputing/compute_gpu.md
+++ b/_scicomputing/compute_gpu.md
@@ -1,22 +1,20 @@
 ---
 title: Computing with GPUs
-last_modified_at: 2019-06-03
+last_modified_at: 2023-03-31
 primary_reviewer: atombaby
 ---
 
 ## Requesting GPUs
 
-GPUs are requested via the GRES option:
+GPUs are requested via the `--gpus` option:
 
-    sbatch --gres=gpu ...
+    sbatch --gpus=1 ...
 
-Request multiple GPUs with:
+Specific GPU models (see table below) can be requested by indicating _model_ and _count_:
 
-    sbatch --gres=gpu:2
+    sbatch --gpus=rtx2080ti:1 ...
 
-At this time we have one GPU per node.
-
-### Nodes with GPUs
+### Nodes GPUs
 
 |Location|Partition|Node Name|GPU|
 |---|:---:|:---:|---:|


### PR DESCRIPTION
Use `--gpus` instead of the GRES interfaces.  Fixes #864 