### PR TITLE
Add R-Ladies to resources

### DIFF
--- a/_scicomputing/software_R.md
+++ b/_scicomputing/software_R.md
@@ -110,4 +110,5 @@ The [Tidyverse](https://www.tidyverse.org/) is a group of R packages that coordi
 
 ## Local resources
 - [Seattle useR group](http://www.meetup.com/Seattle-useR/)
+- [R-Ladies Seattle](https://www.meetup.com/rladies-seattle/)
 - [Cascadia RConf](https://cascadiarconf.com/), a local yearly conference


### PR DESCRIPTION
Adds a link to the R-Ladies Seattle website. 

I used to host these at Fred Hutch and the TDS IRC sponsored us. Maybe more in the future.