### PR TITLE
Add documentation for updates to Java temporary directory handling

### DIFF
--- a/_compdemos/store_job_local.md
+++ b/_compdemos/store_job_local.md
@@ -16,3 +16,7 @@ This local storage is on an attached SSD and has approximately 7TB available on 
 In the _gizmo_ compute cluster the environment variable `$TMPDIR` will be set to the path where this storage has been provisioned.  Currently this variable is set using the job ID and uses the form `/loc/scratch/<jobid>`.  This is a directory unique to the job and owned by you.
 
 > We recommend that you use the environment variable in your scripts rather than generating this path as the path to the job local storage may change.  Using the environment variable will "future proof" your scripts.
+
+## Note for Java, GATK, and Picard Users
+
+As Java (and by extension GATK and Picard) does not follow the _TMPDIR_ convention we set the Java property `java.io.tmpdir` using the environment variable _JAVA_TOOL_OPTIONS_.  This updates the default value- if you are using GATK or Picard specific options to set the temporary directory, that option value will be used.

--- a/_scicompannounce/2024-01-22-java-temporary-directory.md
+++ b/_scicompannounce/2024-01-22-java-temporary-directory.md
@@ -2,13 +2,15 @@
 Title: Java Temporary Directory for Gizmo Jobs
 ---
 
-Java does not use the convention of using the temporary directory path indicated by the _TMPDIR_ environment variable.  Instead it uses its own internal logic and a Java specific property `java.io.tmpdir`.
+On Gizmo we configure a [job local](/compdemos/store_job_local/) directory to be used by jobs- this path points to local storage and creates a managed directory for use by that job.  Once complete, that directory and its contents are removed.  To facilitate use of this path by jobs, we set an environment variable ( _TMPDIR_ ) in the job's environment- _TMPDIR_ is a Linux convention that most tools will use as the path for writing temporary files.
 
-This is most interesting for users of GATK and Picard- these tools use large volumes of temporary disk which frequently results in "disk full" errors.  The default path for that temporary directory is `/tmp` which is much smaller and unmanaged by Slurm.
+Java does not use this convention.  Instead it set the default path for temporary files to `/tmp`.  There is much less space available in this path and the contents of that directory are not managed- over time this leads to disk-full conditions which can cause job failures or cause the node to be taken out of service.
 
-To address these problems we are adding an environment variable to the job's environment which will update the default path for Java temporary files.  This environment variable we are updating is _JAVA_TOOL_OPTIONS_- it will be set to point to the job local directory.
+To address this we are updating the default behavior for Java within a Gizmo job- we are adding the environment variable _JAVA_TOOL_OPTIONS_ and setting it to the job local directory.
 
 For example, a job with ID 12345 have JAVA_TOOL_OPTIONS set to `-Djava.io.tmpdir=/loc/scratch/12345`.
+
+This is most interesting for users of GATK and Picard- these tools use large volumes of temporary disk which frequently results in "disk full" errors.
 
 If you are using this environment variable to set other Java options, those options will be preserved.  If you are setting `java.io.tmpdir` using _JAVA_TOOL_OPTIONS_ your value will be preferred.  If you are setting the temporary directory using GATK and Picard options, those values will be used.
 

--- a/_scicompannounce/2024-01-22-java-temporary-directory.md
+++ b/_scicompannounce/2024-01-22-java-temporary-directory.md
@@ -14,7 +14,7 @@ This is most interesting for users of GATK and Picard- these tools use large vol
 
 If you are using this environment variable to set other Java options, those options will be preserved.  If you are setting `java.io.tmpdir` using _JAVA_TOOL_OPTIONS_ your value will be preferred.  If you are setting the temporary directory using GATK and Picard options, those values will be used.
 
-This will change Java output, adding the following message in the job standard output:
+This change will result in the following message in your job's output:
 
 ```
 Picked up JAVA_TOOL_OPTIONS: -Djava.io.tmpdir=/loc/scratch/27072483

--- a/_scicompannounce/2024-01-22-java-temporary-directory.md
+++ b/_scicompannounce/2024-01-22-java-temporary-directory.md
@@ -1,0 +1,15 @@
+---
+Title: Java Temporary Directory for Gizmo Jobs
+---
+
+Java does not use the convention of using the temporary directory path indicated by the _TMPDIR_ environment variable.  Instead it uses its own internal logic and a Java specific property `java.io.tmpdir`.
+
+This is most interesting for users of GATK and Picard- these tools use large volumes of temporary disk which frequently results in "disk full" errors.  The default path for that temporary directory is `/tmp` which is much smaller and unmanaged by Slurm.
+
+To address these problems we are adding an environment variable to the job's environment which will update the default path for Java temporary files.  This environment variable we are updating is _JAVA_TOOL_OPTIONS_- it will be set to point to the job local directory.
+
+For example, a job with ID 12345 have JAVA_TOOL_OPTIONS set to `-Djava.io.tmpdir=/loc/scratch/12345`.
+
+If you are using this environment variable to set other Java options, those options will be preserved.  If you are setting `java.io.tmpdir` using _JAVA_TOOL_OPTIONS_ your value will be preferred.  If you are setting the temporary directory using GATK and Picard options, those values will be used.
+
+Please contact Scientific Computing if you have any questions.

--- a/_scicompannounce/2024-01-22-java-temporary-directory.md
+++ b/_scicompannounce/2024-01-22-java-temporary-directory.md
@@ -14,4 +14,10 @@ This is most interesting for users of GATK and Picard- these tools use large vol
 
 If you are using this environment variable to set other Java options, those options will be preserved.  If you are setting `java.io.tmpdir` using _JAVA_TOOL_OPTIONS_ your value will be preferred.  If you are setting the temporary directory using GATK and Picard options, those values will be used.
 
+This will change Java output, adding the following message in the job standard output:
+
+```
+Picked up JAVA_TOOL_OPTIONS: -Djava.io.tmpdir=/loc/scratch/27072483
+```
+
 Please contact Scientific Computing if you have any questions.


### PR DESCRIPTION
Adds announcement for today (22 Jan 2024) and adds note to job local storage docs.