### PR TITLE
Adding release notes for v1.0 to the PROOF wiki page

### DIFF
--- a/_datascience/proof.md
+++ b/_datascience/proof.md
@@ -26,7 +26,7 @@ primary_reviewers: vortexing, abbywall
 ## Release Notes
 See our release notes in the PROOF repo for more details: 
 
-### June 2024
+### June 2024 - v1.0
 **What's New**
 - Users can now interact with data stored in S3 buckets within WDL workflows executed in PROOF! Just make sure to have your AWS CLI credentials [established in Rhino](https://sciwiki.fredhutch.org/scicomputing/access_credentials/#configure-aws-cli) and you can use the S3 path just like any other input.
 - GPU analysis is now possible via the `gpu` argument in your WDL task's runtime section! For an example, try running [this example script](https://github.com/getwilds/ww-test-workflows/blob/main/gpuMatrixMult/gpuMatrixMult.wdl) in the [ww-test-workflows](https://github.com/getwilds/ww-test-workflows) repo of the [DaSL WILDS](https://github.com/getwilds).
@@ -42,7 +42,7 @@ See our release notes in the PROOF repo for more details:
 - Table entries that are longer than usual will now be abbreviated to 150 characters or less to ensure a consistent display.
 - A linting GitHub action has been added to the GitHub repository for improved CI/CD. All issues identified by this linting action have also been resolved.
 
-### February 2024
+### February 2024 - v0.1
 **What's New!**
 - PROOF has now grouped together all the components for setting up and configuring your database and Cromwell server so you don’t have to manually configure each part!
 - You can interact with PROOF in two improved ways when running your workflows:

--- a/_datascience/proof.md
+++ b/_datascience/proof.md
@@ -28,7 +28,7 @@ See our release notes in the PROOF repo for more details:
 
 ### June 2024 - PROOF v1.0
 **What's New**
-- Users can now interact with data stored in S3 buckets within WDL workflows executed in PROOF! Just make sure to have your AWS CLI credentials [established in Rhino](https://sciwiki.fredhutch.org/scicomputing/access_credentials/#configure-aws-cli) and you can use the S3 path just like any other input.
+- Users can now interact with data stored in S3 buckets within WDL workflows executed in PROOF! Just make sure to have your AWS CLI credentials [established in Rhino](/scicomputing/access_credentials/#configure-aws-cli) and you can use the S3 path just like any other input.
 - GPU analysis is now possible via the `gpu` argument in your WDL task's runtime section! For an example, try running [this example script](https://github.com/getwilds/ww-test-workflows/blob/main/gpuMatrixMult/gpuMatrixMult.wdl) in the [ww-test-workflows](https://github.com/getwilds/ww-test-workflows) repo of the [DaSL WILDS](https://github.com/getwilds).
 - Additional features have been introduced to increase transparency in terms of the functionality of PROOF:
     - New `/info` API endpoint provides details on which code base is being used.
@@ -37,6 +37,7 @@ See our release notes in the PROOF repo for more details:
 
 **Fixes**
 - The default location of the Apptainer cache directory has been moved from `scratch` to `/hpc/temp` to avoid previously reported linkage issues associated with `scratch`.
+    - If a user's lab/group has not yet been onboarded to `/hpc/temp`, the cache location will default to the user's home directory instead.
 - PROOF's underlying WSGI server has been switched from Waitress to Gunicorn for better scalability and efficiency.
 - Session persistence or "stickiness" has been added to the Shiny app to ensure users only speak to one instance at a time.
 - Table entries that are longer than usual will now be abbreviated to 150 characters or less to ensure a consistent display.

--- a/_datascience/proof.md
+++ b/_datascience/proof.md
@@ -26,10 +26,21 @@ primary_reviewers: vortexing, abbywall
 ## Release Notes
 See our release notes in the PROOF repo for more details: 
 
-### May 2024
+### June 2024
 **What's New**
+- Users can now interact with data stored in S3 buckets within WDL workflows executed in PROOF! Just make sure to have your AWS CLI credentials [established in Rhino](https://sciwiki.fredhutch.org/scicomputing/access_credentials/#configure-aws-cli) and you can use the S3 path just like any other input.
+- GPU analysis is now possible via the `gpu` argument in your WDL task's runtime section! For an example, try running [this example script](https://github.com/getwilds/ww-test-workflows/blob/main/gpuMatrixMult/gpuMatrixMult.wdl) in the [ww-test-workflows](https://github.com/getwilds/ww-test-workflows) repo of the [DaSL WILDS](https://github.com/getwilds).
+- Additional features have been introduced to increase transparency in terms of the functionality of PROOF:
+    - New `/info` API endpoint provides details on which code base is being used.
+    - Server start date and time is now available on the "PROOF Server" tab.
+    - Documentation links have been added to the "Welcome" tab and automated server creation email for increased visibility.
 
 **Fixes**
+- The default location of the Apptainer cache directory has been moved from `scratch` to `/hpc/temp` to avoid previously reported linkage issues associated with `scratch`.
+- PROOF's underlying WSGI server has been switched from Waitress to Gunicorn for better scalability and efficiency.
+- Session persistence or "stickiness" has been added to the Shiny app to ensure users only speak to one instance at a time.
+- Table entries that are longer than usual will now be abbreviated to 150 characters or less to ensure a consistent display.
+- A linting GitHub action has been added to the GitHub repository for improved CI/CD. All issues identified by this linting action have also been resolved.
 
 ### February 2024
 **What's New!**

--- a/_datascience/proof.md
+++ b/_datascience/proof.md
@@ -26,7 +26,7 @@ primary_reviewers: vortexing, abbywall
 ## Release Notes
 See our release notes in the PROOF repo for more details: 
 
-### June 2024 - v1.0
+### June 2024 - PROOF v1.0
 **What's New**
 - Users can now interact with data stored in S3 buckets within WDL workflows executed in PROOF! Just make sure to have your AWS CLI credentials [established in Rhino](https://sciwiki.fredhutch.org/scicomputing/access_credentials/#configure-aws-cli) and you can use the S3 path just like any other input.
 - GPU analysis is now possible via the `gpu` argument in your WDL task's runtime section! For an example, try running [this example script](https://github.com/getwilds/ww-test-workflows/blob/main/gpuMatrixMult/gpuMatrixMult.wdl) in the [ww-test-workflows](https://github.com/getwilds/ww-test-workflows) repo of the [DaSL WILDS](https://github.com/getwilds).
@@ -42,7 +42,7 @@ See our release notes in the PROOF repo for more details:
 - Table entries that are longer than usual will now be abbreviated to 150 characters or less to ensure a consistent display.
 - A linting GitHub action has been added to the GitHub repository for improved CI/CD. All issues identified by this linting action have also been resolved.
 
-### February 2024 - v0.1
+### February 2024 - PROOF v0.1
 **What's New!**
 - PROOF has now grouped together all the components for setting up and configuring your database and Cromwell server so you don’t have to manually configure each part!
 - You can interact with PROOF in two improved ways when running your workflows:


### PR DESCRIPTION
## Description
With the recent "v1.0" release of the overarching PROOF project, we are adding release notes to the PROOF product pages describing what has changed since it's original rollout. For more details, please visit the [PROOF umbrella repository](https://github.com/getwilds/proof/).