### PR TITLE
update the Mac Finder path to /hpc/temp

### DIFF
--- a/_scicompannounce/2024-04-02-new-hpc-temp-storage.md
+++ b/_scicompannounce/2024-04-02-new-hpc-temp-storage.md
@@ -10,7 +10,7 @@ RITSC now supports a new temporary data storage platform for use by HPC cluster 
 
 ## How
 The new storage platform is mounted on all cluster nodes, including rhinos, at `/hpc/temp`. In order to provide a high performance shared storage platform for all cluster users, all data written to _temp_ will be deleted 30 days after creation (this is a change from scratch). In order to use this new system, *all labs* will need to send an email to scicomp@fredhutch.org from lab leadership (data owner/PI/data steward) to have a folder created for read/write access. Once the folder is created, it can also be accessed
-from the Mac Finder at `smb://hpc.chromium.fhcrc.org/temp.chromium` or Windows Explorer at `\\hpc.chromium.fhcrc.org\temp.chromium`.
+from the Mac Finder at `smb://fhcrc.org;USERNAME@hpc.chromium.fhcrc.org/temp.chromium` (replacing `USERNAME` with your HutchNet ID) or Windows Explorer at `\\hpc.chromium.fhcrc.org\temp.chromium`.
 
 ## When
 The storage platform is available now.

--- a/_scicomputing/store_posix.md
+++ b/_scicomputing/store_posix.md
@@ -86,6 +86,7 @@ The following is a summary of how to access these storage systems from PC, Mac o
 | Fast | `X:\fast` |
 | Scratch | `X:\scratch` |
 | Secure | `X:\secure` |
+| HPC Temp | `\\hpc.chromium.fhcrc.org\temp.chromium` |
 
 
 **Non-Fred Hutch PC:**
@@ -96,7 +97,7 @@ The following is a summary of how to access these storage systems from PC, Mac o
 | Fast | `\\center.fhcrc.org\fh\fast` |
 | Scratch | `\\center.fhcrc.org\fh\scratch` |
 | Secure | `\\center.fhcrc.org\fh\secure` |
-
+| HPC Temp | `\\hpc.chromium.fhcrc.org\temp.chromium` |
 
 **Mac:**
 
@@ -108,6 +109,7 @@ For these paths, replace HUTCHID with your hutchid.
 | Fast | `smb://fhcrc.org;HUTCHID@center.fhcrc.org/fh/fast` |
 | Scratch | `smb://fhcrc.org;HUTCHID@center.fhcrc.org/fh/scratch` |
 | Secure | `smb://fhcrc.org;HUTCHID@center.fhcrc.org/fh/secure` |
+| HPC Temp | `smb://fhcrc.org;HUTCHID@hpc.chromium.fhcrc.org/temp.chromium` |
 
 Note: Drive mapping with Macs can be very slow for large volumes due to the Mac wanting to index every file in a volume. Turn off volume indexing to improve the speed of drive mapping. 
 From a terminal window on your Mac, turn off all drive mapping.

--- a/_scicomputing/store_posix.md
+++ b/_scicomputing/store_posix.md
@@ -88,7 +88,6 @@ The following is a summary of how to access these storage systems from PC, Mac o
 | Secure | `X:\secure` |
 | HPC Temp | `\\hpc.chromium.fhcrc.org\temp.chromium` |
 
-
 **Non-Fred Hutch PC:**
 
 | Location | Path |

--- a/_scicomputing/store_temp.md
+++ b/_scicomputing/store_temp.md
@@ -43,4 +43,4 @@ A: No- all data on _temp_ is confined to the storage system in the data center. 
 
 #### Q: Can I access _temp_ from my Windows or Mac workstation
 
-A: _temp_ can also be accessed from the Mac Finder at `smb://hpc.chromium.fhcrc.org/temp.chromium` or Windows Explorer at `\\hpc.chromium.fhcrc.org\temp.chromium`.
+A: _temp_ can also be accessed from the Mac Finder at `smb://fhcrc.org;USERNAME@hpc.chromium.fhcrc.org/temp.chromium` (replacing `USERNAME` with your HutchNet ID) or Windows Explorer at `\\hpc.chromium.fhcrc.org\temp.chromium`.


### PR DESCRIPTION
We have had two tickets from users for whom the original Mac Finder path that we had documented (`smb://hpc.chromium.fhcrc.org/temp.chromium`) did not work. Changing the path to `smb://fhcrc.org;USERNAME@hpc.chromium.fhcrc.org/temp.chromium` worked in both cases, so I figured we should document the path that works.

I am not sure why the original path stopped working and why the new one works (@atombaby can weigh in on that).

I'm also not sure if Windows users will run into the same issue, and if so, what the corresponding UNC path would be. If you know, can you add it to this PR?