### PR TITLE
Fix order of arguments in S3 help command

### DIFF
--- a/_compdemos/aws-s3.md
+++ b/_compdemos/aws-s3.md
@@ -101,7 +101,7 @@ aws s3 help
 for more information. To see documentation for a specific s3 subcommand, such as `cp`, do this:
 
 ```
-aws s3 help cp
+aws s3 cp help
 
 ```
 


### PR DESCRIPTION
The previous command had arguments reversed;
`aws s3 help cp` returns an error.