### PR TITLE
Real-world data

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -71,7 +71,7 @@ datascience:
   - title: Biomedical Data
     children:
       - title: Real-World Data
-        url: datascience/real-world-data/
+        url: datascience/real_world_data/
       - title: Patient Data
         url: /datascience/patient-data/
   -title: Data Science

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -74,7 +74,7 @@ datascience:
         url: datascience/real_world_data/
       - title: Patient Data
         url: /datascience/patient-data/
-  -title: Data Science
+  - title: Data Science
     children:
       - title: Data Visualization
         url: /datascience/data_viz/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -64,16 +64,20 @@ datascience:
         url: /datascience/execute_sharing/
       - title: Specimen Data Management
         url: /datascience/open_specimen/
-  - title: Working With Data
-    children:
-      - title: Data Visualization
-        url: /datascience/data_viz/
-      - title: Patient Data
-        url: /datascience/patient-data/
       - title: PHI and Research
         url: /datascience/phi/
       - title: Data Deidentification
         url: /datascience/deidentification/
+  - title: Biomedical Data
+    children:
+      - title: Real-World Data
+        url: datascience/real-world-data/
+      - title: Patient Data
+        url: /datascience/patient-data/
+  -title: Data Science
+    children:
+      - title: Data Visualization
+        url: /datascience/data_viz/
   - title: Research, Privacy and Security
     children:
       - title: Consenting and the IRB

--- a/_datascience/real_world_data.md
+++ b/_datascience/real_world_data.md
@@ -1,0 +1,68 @@
+---
+title: Real-World Data in Oncology Research 
+primary_reviewers: monicagerber
+---
+
+[Real-world data](https://toolkit.ncats.nih.gov/glossary/real-world-data/) (RWD) are “data relating to patient health status and/or the delivery of health care routinely collected provided outside of a research setting,” for example, data from electronic health records or cancer registries. On this page we outline types of RWD used in oncology research and resources to learn more about real-world evidence (RWE) generation at Fred Hutch and beyond. 
+
+## Sources of RWD
+
+There are few major sources of RWD:
+
+- Administrative Claims 
+- Registries
+- Large-scale harmonized databases
+- Electronic health records (EHRs)
+
+### Administrative Claims
+
+Administrative claims data are data generated for the purposes of health care billing. Claims data originate from the federal government (Medicare), state-level governments (e.g., Medicaid programs), commercial insurance providers, and other aggregators of health care claims. 
+
+[Washington State All-Payer Claims Database](https://www.hca.wa.gov/about-hca/data-and-reports/washington-state-all-payer-claims-database-wa-apcd) (WA-APCD)
+
+### Registries 
+
+[Patient registries](https://toolkit.ncats.nih.gov/module/discovery/starting-a-patient-registry-natural-history-study-database/patient-registries/) are databases that collect information about people “diagnosed with a specific disease, genetic disorder, or medical condition.” There are several registries that are important for understanding the distribution and burden of cancer in the United States.
+
+The CDC’s [National Program of Cancer Registries](https://www.cdc.gov/national-program-cancer-registries/index.html) (NPCR) supports state/local data collection and the [North American Association of Central Cancer Registries](https://www.naaccr.org) (NAACCR) standardizes the data from NPCR and other registries in the US and Canada. The NPCR covers 96% of the US population.
+
+The National Cancer Institute’s (NCI) [Surveillance, Epidemiology, and End Results](https://seer.cancer.gov) (SEER) program covers 48% of the US population, but contains more detailed surveillance of cancer type and population-specific trends. SEER also links to administrative claims data, such as Medicare. The NCI also runs the [National Childhood Cancer Registry](https://nccrexplorer.ccdi.cancer.gov) (NCCR).
+
+Another registry is the combined effort of the Commission on Cancer (CoC), American Cancer Society, and the American College of Surgeons: the [National Cancer Database](https://www.facs.org/quality-programs/cancer-programs/national-cancer-database/) (NCDB). This hospital-based registry covers around 70% of the American population and contains data from CoC-accredited hospitals. 
+
+The CDC maintains the [US Cancer Statistics database](https://www.cdc.gov/united-states-cancer-statistics/index.html), which includes national-level reporting on cancer burden. It combines data from NPCR and SEER.
+
+###  Large-scale harmonized databases
+
+Both commercial vendors and non-profit organizations provide data products offering [harmonized](https://www.nature.com/articles/s41597-024-02956-3) medical record data. Some are specific to cancer care, and others are more general healthcare databases. Some examples are ASCO’s CancerLinQ, Truveta, and Flatiron Health. 
+
+### Institutional electronic health record data
+
+Institution-specific EHR data (both raw and processed/transformed) are often available in institutional data warehouses. The barriers to using these data in clinical research include lack of data standardization, proprietary data models, data quality issues, selection biases inherent in using data generated from healthcare utilization, and more. Efforts such the [Observational Health Data Sciences and Informatics](https://ohdsi.org) (OHDSI) program aim to address these issues and provide open-source solutions. 
+
+
+## Real-World Data Stewardship at Fred Hutch
+
+There are several groups and departments at Fred Hutch that play a critical role in stewardship of RWD and real-world evidence generation. 
+
+[The Cancer Registry](https://fredhutch.sharepoint.com/sites/TogetherNet/cancerregistry) (internal link) at Fred Hutch collects data on analytic cases among Fred Hutch patients and reports this data up to regional, state, and national-level registries.
+
+The [Cancer Surveillance System ](https://www.fredhutch.org/en/research/divisions/public-health-sciences-division/research/epidemiology/cancer-surveillance-system.html) (CSS) at Fred Hutch is part of SEER and collects data from 13 western WA counties. This data is then reported up to the Washington State Department of Health, merged with data from across Washington state, and then reported up to the NCI’s SEER program.
+
+The [Hutch Institute for Cancer Outcomes Research](https://www.fredhutch.org/en/research/institutes-networks-ircs/hutchinson-institute-for-cancer-outcomes-research.html) (HICOR) conducts essential research to “improve cancer prevention, detection and treatment in ways that will reduce the economic and human burden of cancer.” HICOR maintains access to the following data resources for Fred Hutch researchers:
+
+- [SEER Patterns of Care](https://healthcaredelivery.cancer.gov/poc/)
+- [SEER-Medical Health Outcomes Survey](https://healthcaredelivery.cancer.gov/seer-mhos/)
+- [SEER-Consumer Assessment of Healthcare Providers and Systems](https://healthcaredelivery.cancer.gov/seer-cahps/) (CAHPS) surveys 
+- [SEER Medicare](https://healthcaredelivery.cancer.gov/seermedicare/) linked data resource (includes Medicare Advantage plans)
+- [SEER Medicaid](https://healthcaredelivery.cancer.gov/seermedicaid/) linked data resource
+- [Health Economics Research On Cancer](https://healthcaredelivery.cancer.gov/heroic) (HEROiC) 
+
+The [Office of the Chief Data Officer](https://centernet.fredhutch.org/u/data-science-lab/patient-data.html) at Fred Hutch manages data access for Fred Hutch patient data for research. 
+
+## Resources to Learn More
+
+- [Oncologists Must Consider Participant Data When Using Large-Scale Cancer Data Sets](https://doi.org/10.1200/CCI.23.00245)
+- [Real-World Database Studies in Oncology: A Call for Standards](https://doi.org/10.1200/JCO.23.0239)
+- [Assessing Real-World Data From Electronic Health Records for Health Technology Assessment: The SUITABILITY Checklist: A Good Practices Report of an ISPOR Task Force](https://doi.org/10.1016/j.jval.2024.01.019)
+- [An overview of real-world data sources for oncology and considerations for research](https://doi.org/10.3322/caac.21714)

--- a/_datascience/real_world_data.md
+++ b/_datascience/real_world_data.md
@@ -40,10 +40,6 @@ Both commercial vendors and non-profit organizations provide data products offer
 
 Institution-specific EHR data (both raw and processed/transformed) are often available in institutional data warehouses. The barriers to using these data in clinical research include lack of data standardization, proprietary data models, data quality issues, selection biases inherent in using data generated from healthcare utilization, and more. Efforts such the [Observational Health Data Sciences and Informatics](https://ohdsi.org) (OHDSI) program aim to address these issues and provide open-source solutions. 
 
-#### Data from wearable devices 
-
-In clinical practice, consumer-grade wearable devices are increasingly being used to support prediction, treatment monitoring, and rehabilitation ([review](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10994271/)). Because wearable devices are relatively new, proprietary, and rapidly changing, there are many open questions about the validity of specific endpoints and the correlation of measures across device types. Other barriers to the use of this data include the cost of devices, the difficulty of interpreting the data, and high missingness rates.
-
 ## Real-World Data Stewardship at Fred Hutch
 
 There are several groups and departments at Fred Hutch that play a critical role in stewardship of RWD and in real-world evidence generation. 

--- a/_datascience/real_world_data.md
+++ b/_datascience/real_world_data.md
@@ -9,7 +9,7 @@ primary_reviewers: monicagerber
 
 There are few major sources of RWD:
 
-- Administrative Claims 
+- Administrative claims 
 - Registries
 - Large-scale harmonized databases
 - Electronic health records (EHRs)
@@ -28,24 +28,23 @@ The CDC’s [National Program of Cancer Registries](https://www.cdc.gov/national
 
 The National Cancer Institute’s (NCI) [Surveillance, Epidemiology, and End Results](https://seer.cancer.gov) (SEER) program covers 48% of the US population, but contains more detailed surveillance of cancer type and population-specific trends. SEER also links to administrative claims data, such as Medicare. The NCI also runs the [National Childhood Cancer Registry](https://nccrexplorer.ccdi.cancer.gov) (NCCR).
 
-Another registry is the combined effort of the Commission on Cancer (CoC), American Cancer Society, and the American College of Surgeons: the [National Cancer Database](https://www.facs.org/quality-programs/cancer-programs/national-cancer-database/) (NCDB). This hospital-based registry covers around 70% of the American population and contains data from CoC-accredited hospitals. 
+The [National Cancer Database](https://www.facs.org/quality-programs/cancer-programs/national-cancer-database/) (NCDB) is the combined effort of the Commission on Cancer (CoC), American Cancer Society, and the American College of Surgeons. This hospital-based registry covers around 70% of the American population and contains data from CoC-accredited hospitals. 
 
 The CDC maintains the [US Cancer Statistics database](https://www.cdc.gov/united-states-cancer-statistics/index.html), which includes national-level reporting on cancer burden. It combines data from NPCR and SEER.
 
 ###  Large-scale harmonized databases
 
-Both commercial vendors and non-profit organizations provide data products offering [harmonized](https://www.nature.com/articles/s41597-024-02956-3) medical record data. Some are specific to cancer care, and others are more general healthcare databases. Some examples are ASCO’s CancerLinQ, Truveta, and Flatiron Health. 
+Both commercial vendors and non-profit organizations provide data products offering [harmonized](https://www.nature.com/articles/s41597-024-02956-3) medical record and claims data. Some are specific to cancer care, and others are more general healthcare databases. Some examples are ASCO’s CancerLinQ, Truveta, and Flatiron Health. 
 
 ### Institutional electronic health record data
 
 Institution-specific EHR data (both raw and processed/transformed) are often available in institutional data warehouses. The barriers to using these data in clinical research include lack of data standardization, proprietary data models, data quality issues, selection biases inherent in using data generated from healthcare utilization, and more. Efforts such the [Observational Health Data Sciences and Informatics](https://ohdsi.org) (OHDSI) program aim to address these issues and provide open-source solutions. 
 
-
 ## Real-World Data Stewardship at Fred Hutch
 
-There are several groups and departments at Fred Hutch that play a critical role in stewardship of RWD and real-world evidence generation. 
+There are several groups and departments at Fred Hutch that play a critical role in stewardship of RWD and in real-world evidence generation. 
 
-[The Cancer Registry](https://fredhutch.sharepoint.com/sites/TogetherNet/cancerregistry) (internal link) at Fred Hutch collects data on analytic cases among Fred Hutch patients and reports this data up to regional, state, and national-level registries.
+[The Cancer Registry](https://fredhutch.sharepoint.com/sites/TogetherNet/cancerregistry) (internal link) at Fred Hutch collects data on [analytic cases](https://doh.wa.gov/sites/default/files/legacy/Documents/Pubs//140-193-ReportableNonReportableClassofCaseTypes.pdf) and some non-analytic cases among Fred Hutch patients, and reports this data up to regional, state, and national-level registries.
 
 The [Cancer Surveillance System ](https://www.fredhutch.org/en/research/divisions/public-health-sciences-division/research/epidemiology/cancer-surveillance-system.html) (CSS) at Fred Hutch is part of SEER and collects data from 13 western WA counties. This data is then reported up to the Washington State Department of Health, merged with data from across Washington state, and then reported up to the NCI’s SEER program.
 

--- a/_datascience/real_world_data.md
+++ b/_datascience/real_world_data.md
@@ -40,6 +40,10 @@ Both commercial vendors and non-profit organizations provide data products offer
 
 Institution-specific EHR data (both raw and processed/transformed) are often available in institutional data warehouses. The barriers to using these data in clinical research include lack of data standardization, proprietary data models, data quality issues, selection biases inherent in using data generated from healthcare utilization, and more. Efforts such the [Observational Health Data Sciences and Informatics](https://ohdsi.org) (OHDSI) program aim to address these issues and provide open-source solutions. 
 
+#### Data from wearable devices 
+
+In clinical practice, consumer-grade wearable devices are increasingly being used to support prediction, treatment monitoring, and rehabilitation ([review](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10994271/)). Because wearable devices are relatively new, proprietary, and rapidly changing, there are many open questions about the validity of specific endpoints and the correlation of measures across device types. Other barriers to the use of this data include the cost of devices, the difficulty of interpreting the data, and high missingness rates.
+
 ## Real-World Data Stewardship at Fred Hutch
 
 There are several groups and departments at Fred Hutch that play a critical role in stewardship of RWD and in real-world evidence generation. 


### PR DESCRIPTION
This PR:

- creates a new page on real-world data
- suggests a new sidebar organization 

The "PHI and Research" and "Data De-Identification" pages are moved under "Data Management and Sharing." 

I created "Biomedical Data" and "Data Science." I am hoping that in the future the Biomedical Data tab will include more information about public genomics data sets or other FH-specific resources. Data Science will be expanded to contain more resources on machine learning, statistics, and visualization. 

I would appreciate a review of the RWD page to make sure that the language is clear and I am not missing any critical Hutch resources. 