### PR TITLE
adding small documentaiton for new AWS Org

### DIFF
--- a/_scicomputing/access_aws.md
+++ b/_scicomputing/access_aws.md
@@ -35,6 +35,16 @@ Here are some links to learn more. Keep in mind that tools provided by AWS will 
 •	[AWS Pricing 101](https://aws.amazon.com/pricing/?aws-products-pricing.sort-by=item.additionalFields.productNameLowercase&aws-products-pricing.sort-order=asc&awsf.Free%20Tier%20Type=*all&awsf.tech-category=*all)
 •	[AWS Pricing Calculator](https://calculator.aws/#/?nc2=pr)
 
+## Accessing via SSO
+In 2024 Fred Hutch undertook a large migration to move all PI and Divisional AWS account to a new, more secure architecture. One of the benefits of this is integration with our Fred Hutch domain, meaning a user can now log into their AWS account using their Fred Hutch credentials. To access your account using your Fred Hutch credentials, naviagte to the [SSO Landing Page](https://d-92674cb6d7.awsapps.com/start). Once authenticated you should see all the accounts which you have access, you may then login and use the console normally. 
+
+For secret/access key access you can provision temporary credentials through the webpage, or [configure your AWS CLI to use SSO](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html)
+
+## Cost Anomoly Detection
+Within your Lab accounts, if you are a PI or a delegated account admin, you can set up [Cost Anomoly Detection](https://docs.aws.amazon.com/cost-management/latest/userguide/getting-started-ad.html) to better track costs. Exact costs charged by Fred Hutch BizOps will differ from AWS costs. For further details on chargebacks, you can join the [AWS Chargebacks Teams Channel](https://teams.microsoft.com/l/channel/19:86nu83-f_YlZdMcyP7OFIKxyW_1DmMWp3woTI90H2bM1@thread.tacv2/General?groupId=24987ba0-f4d9-4a11-8de1-150b4c971610&tenantId=0054a3ea-b394-418b-ad1a-174138231fd6) where there is further documentation on chargebacks and BizOps is available to answer more specific questions
+
+## Delegate Account Admins
+By default, a PI is the admin the of their lab's AWS account. But there may be cases where another member of the lab is requested to be a delegated account admin. This come with additional permissions to monitor and manage the AWS account. In order to become a delegated account admin you need PI approval and to open a ticket with IAM to get you added to the `Power User` group for your lab's AWS Account
 
 ## I have more questions
 


### PR DESCRIPTION
Adding a few small new sections to the AWS Access page for logging into AWS Accounts in the new org. Sounds like there will be a larger discussion on where Cloud Team documentation will live long term, but a lot the current AWS documentation lives in SciComp's space which still makes sense in a lot of ways. 

We can use build on SciComp's existing pages, or work on making our own space in the future. We will need to update a lot of the documentation in the near future, but this is our first update since beginning the migration project