### PR TITLE
PROOF Documentation Update

### DIFF
--- a/_dasldemos/proof-how-to.md
+++ b/_dasldemos/proof-how-to.md
@@ -4,6 +4,10 @@ main_authors: vortexing, sitapriyamoorthi
 primary_reviewers: vortexing
 ---
 
+**NEED TO UPDATE SCREENSHOTS WITH NEW GUI!!!**
+**NEED TO UPDATE SCREENSHOTS WITH NEW GUI!!!**
+**NEED TO UPDATE SCREENSHOTS WITH NEW GUI!!!**
+
 
 **PROOF** (**PR**oduction **O**n-ramp for **O**ptimization and **F**easibility) is a user-friendly tool designed for managing and executing [**WDL**](https://docs.openwdl.org/en/1.0.0/) (Workflow Description Language) workflows using the [**Cromwell**](https://cromwell.readthedocs.io/en/stable/) workflow manager, configured to run on the [**Fred Hutch cluster**](https://sciwiki.fredhutch.org/scicomputing/compute_jobs/). PROOF allows users to:
 

--- a/_dasldemos/proof-troubleshooting.md
+++ b/_dasldemos/proof-troubleshooting.md
@@ -4,6 +4,10 @@ main_authors: tefirman
 primary_reviewers: laderast
 ---
 
+**NEED TO UPDATE SCREENSHOTS WITH NEW GUI!!!**
+**NEED TO UPDATE SCREENSHOTS WITH NEW GUI!!!**
+**NEED TO UPDATE SCREENSHOTS WITH NEW GUI!!!**
+
 For users that have a well-tested and established WDL workflow, the [PROOF How-To documentation](/dasldemos/proof-how-to/) should provide enough guidance to help a user through a typical process of job submission. However, while developing a new and untested WDL workflow, it's common to run into all sorts of issues, some as simple as typos, others as complex as entire software environments. The goal of this guide is to teach users where to find (and how to interpret) the more advanced features and behaviors of PROOF in order to debug their custom WDL scripts and get their research up and running. 
 
 ## Common PROOF Server Issues


### PR DESCRIPTION
## Description
- With the new GUI coming in v1.2, DaSL/SciComp needs to update the "How To" and "Troubleshooting" SciWiki documentation for PROOF to account for the interface changes.
- Mostly screenshot updates, but also verifying that instructions are still relevant.