### PR TITLE
define --db_dir parameter to run_alphafold.py

### DIFF
--- a/_compdemos/alphafold3.md
+++ b/_compdemos/alphafold3.md
@@ -67,7 +67,8 @@ apptainer exec \
   python /app/alphafold/run_alphafold.py \
   --json_path=$JSON_PATH \
   --model_dir=$MODEL_PATH \
-  --output_dir=$OUTPUT_DIR
+  --output_dir=$OUTPUT_DIR \
+  --db_dir=/root/public_databases
 ```
 
 If the above script is saved as `script.sh`, you can run it with the command `sbatch script.sh`.


### PR DESCRIPTION
This one is semi-urgent. The example script was missing a flag to `run_alphafold.py` that is needed, but was not exercised by our simple test case. This was discovered when a real user tried to run it with real data.

