### PR TITLE
you can now download build artifacts of any successful wiki build on any branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ build:
     - sc-swarm
   artifacts:
     paths:
-      - site.zip
+      - artifact.zip
     expire_in: 2w
   script: |
     set -x
@@ -71,9 +71,12 @@ build:
   
   
     echo "Host-side check of _site:"
+
     ls -altr _site
 
-    zip -rv site.zip _site
+    # cd _site
+    # zip -r ../artifact.zip ./*
+    zip -rv artifact.zip _site/
 
     # docker run --rm --name grab-site-files \
     #   -v $(pwd):/data sc-registry.fredhutch.org/wiki:test \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,13 +62,11 @@ build:
     # build image
     docker build --build-arg JEKYLL_ENV=$JEKYLL_ENV -t sc-registry.fredhutch.org/wiki:test .
 
+    # create artifact
+    rm -rf html/ # we are going to recreate it
     docker create --name grab-site-files sc-registry.fredhutch.org/wiki:test
     docker cp grab-site-files:/usr/share/nginx/html ./
     docker rm grab-site-files
-  
-    echo "Host-side check of html:"
-
-    ls -altr html/
 
     docker push sc-registry.fredhutch.org/wiki:test
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ build:
     pwd
 
     docker run --rm --name grab-site-files \
-      -v $(pwd):/data sc-registry.fredhutch.org/wiki:test \
+      -v /builds/FredHutch/wiki:/data sc-registry.fredhutch.org/wiki:test \
       sh -c "mkdir -p /data/_site && cp -r /usr/share/nginx/html/* /data/_site/"
     ls -l
     # docker run --rm --name grab-site-files \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,10 @@ build:
   stage: build
   tags: # TODO REMOVE after shell runner is disabled
     - sc-swarm
+  artifacts:
+    paths:
+      - _site
+    expire_in: 2w
   script: |
     set -x
     # put info about this commit/branch into /info.txt
@@ -57,6 +61,10 @@ build:
     fi
     # build image
     docker build --build-arg JEKYLL_ENV=$JEKYLL_ENV -t sc-registry.fredhutch.org/wiki:test .
+    rm -rf _site && mkdir _site
+    docker run --rm --name grab-site-files \
+      -v $(pwd):/data sc-registry.fredhutch.org/wiki:test \
+      sh -c "cp -r /usr/share/nginx/html/* /data/_site/"
     docker push sc-registry.fredhutch.org/wiki:test
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ build:
     - sc-swarm
   artifacts:
     paths:
-      - artifact.zip
+      - _site
     expire_in: 2w
   script: |
     set -x
@@ -76,7 +76,6 @@ build:
 
     # cd _site
     # zip -r ../artifact.zip ./*
-    zip -rv artifact.zip _site/
 
     # docker run --rm --name grab-site-files \
     #   -v $(pwd):/data sc-registry.fredhutch.org/wiki:test \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,11 +21,11 @@ stages:
 build:
   stage: build
   tags: # TODO REMOVE after shell runner is disabled
-  #   - sc-swarm
-  # artifacts:
-  #   paths:
-  #     - _site
-  #   expire_in: 2w
+    - sc-swarm
+  artifacts:
+    paths:
+      - _site
+    expire_in: 2w
   script: |
     set -x
     # put info about this commit/branch into /info.txt
@@ -61,13 +61,13 @@ build:
     fi
     # build image
     docker build --build-arg JEKYLL_ENV=$JEKYLL_ENV -t sc-registry.fredhutch.org/wiki:test .
-    rm -rf _site && mkdir _site
-    # docker run --rm --name grab-site-files \
-    #   -v $(pwd):/data sc-registry.fredhutch.org/wiki:test \
-    #   sh -c "cp -r /usr/share/nginx/html/* /data/_site/"
+    # rm -rf _site && mkdir _site
     docker run --rm --name grab-site-files \
       -v $(pwd):/data sc-registry.fredhutch.org/wiki:test \
-      sh -c "ls -l /data"
+      sh -c "mkdir -p /data/_site && cp -r /usr/share/nginx/html/* /data/_site/"
+    # docker run --rm --name grab-site-files \
+    #   -v $(pwd):/data sc-registry.fredhutch.org/wiki:test \
+    #   sh -c "ls -l /data"
     docker push sc-registry.fredhutch.org/wiki:test
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,9 +63,11 @@ build:
     docker build --build-arg JEKYLL_ENV=$JEKYLL_ENV -t sc-registry.fredhutch.org/wiki:test .
     rm -rf _site && mkdir _site
     docker run --rm --name grab-site-files \
-      -v $CI_PROJECT_DIR:/data sc-registry.fredhutch.org/wiki:test \
-      sh -c "cp -r /usr/share/nginx/html/* /data/_site/"
-    ls -l
+      -v $CI_PROJECT_DIR/_site:/data sc-registry.fredhutch.org/wiki:test \
+      sh -c "cp -r /usr/share/nginx/html/* /data/"
+    ls -altr
+    echo _site:
+    ls -altr _site
     # docker run --rm --name grab-site-files \
     #   -v $(pwd):/data sc-registry.fredhutch.org/wiki:test \
     #   sh -c "ls -l /data"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,9 +62,13 @@ build:
     # build image
     docker build --build-arg JEKYLL_ENV=$JEKYLL_ENV -t sc-registry.fredhutch.org/wiki:test .
     # rm -rf _site && mkdir _site
+    echo current directory is
+    pwd
+
     docker run --rm --name grab-site-files \
       -v $(pwd):/data sc-registry.fredhutch.org/wiki:test \
       sh -c "mkdir -p /data/_site && cp -r /usr/share/nginx/html/* /data/_site/"
+    ls -l
     # docker run --rm --name grab-site-files \
     #   -v $(pwd):/data sc-registry.fredhutch.org/wiki:test \
     #   sh -c "ls -l /data"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ build:
     - sc-swarm
   artifacts:
     paths:
-      - _site
+      - html
     expire_in: 2w
   script: |
     set -x
@@ -62,24 +62,14 @@ build:
     # build image
     docker build --build-arg JEKYLL_ENV=$JEKYLL_ENV -t sc-registry.fredhutch.org/wiki:test .
 
-
-    rm -rf _site && mkdir _site
-
     docker create --name grab-site-files sc-registry.fredhutch.org/wiki:test
-    docker cp grab-site-files:/usr/share/nginx/html _site
+    docker cp grab-site-files:/usr/share/nginx/html ./
     docker rm grab-site-files
   
-  
-    echo "Host-side check of _site:"
+    echo "Host-side check of html:"
 
-    ls -altr _site
+    ls -altr html/
 
-    # cd _site
-    # zip -r ../artifact.zip ./*
-
-    # docker run --rm --name grab-site-files \
-    #   -v $(pwd):/data sc-registry.fredhutch.org/wiki:test \
-    #   sh -c "ls -l /data"
     docker push sc-registry.fredhutch.org/wiki:test
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 default:
   before_script:
     - apk update
-    - apk --no-cache add py3-pip python3 curl git jq bash
+    - apk --no-cache add py3-pip python3 curl git jq bash zip
     #- pip install pip==21.3.1 # workaround: https://stackoverflow.com/a/72469586/470769
 
     - pip3 install --break-system-packages pyyaml
@@ -24,7 +24,7 @@ build:
     - sc-swarm
   artifacts:
     paths:
-      - _site
+      - site.zip
     expire_in: 2w
   script: |
     set -x
@@ -61,13 +61,21 @@ build:
     fi
     # build image
     docker build --build-arg JEKYLL_ENV=$JEKYLL_ENV -t sc-registry.fredhutch.org/wiki:test .
+
+
     rm -rf _site && mkdir _site
+
+
     docker run --rm --name grab-site-files \
-      -v $CI_PROJECT_DIR/_site:/data sc-registry.fredhutch.org/wiki:test \
-      sh -c "cp -r /usr/share/nginx/html/* /data/"
-    ls -altr
-    echo _site:
+      -v "$CI_PROJECT_DIR/_site:/data" \
+      sc-registry.fredhutch.org/wiki:test \
+      sh -c "ls -l /usr/share/nginx/html && cp -r /usr/share/nginx/html/* /data/ && ls -l /data"
+
+    echo "Host-side check of _site:"
     ls -altr _site
+
+    zip -rv site.zip _site
+
     # docker run --rm --name grab-site-files \
     #   -v $(pwd):/data sc-registry.fredhutch.org/wiki:test \
     #   sh -c "ls -l /data"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,11 +21,11 @@ stages:
 build:
   stage: build
   tags: # TODO REMOVE after shell runner is disabled
-    - sc-swarm
-  artifacts:
-    paths:
-      - _site
-    expire_in: 2w
+  #   - sc-swarm
+  # artifacts:
+  #   paths:
+  #     - _site
+  #   expire_in: 2w
   script: |
     set -x
     # put info about this commit/branch into /info.txt
@@ -62,14 +62,18 @@ build:
     # build image
     docker build --build-arg JEKYLL_ENV=$JEKYLL_ENV -t sc-registry.fredhutch.org/wiki:test .
     rm -rf _site && mkdir _site
+    # docker run --rm --name grab-site-files \
+    #   -v $(pwd):/data sc-registry.fredhutch.org/wiki:test \
+    #   sh -c "cp -r /usr/share/nginx/html/* /data/_site/"
     docker run --rm --name grab-site-files \
       -v $(pwd):/data sc-registry.fredhutch.org/wiki:test \
-      sh -c "cp -r /usr/share/nginx/html/* /data/_site/"
+      sh -c "ls -l /data"
     docker push sc-registry.fredhutch.org/wiki:test
 
 
 
 test:
+  dependencies: []
   stage: test
   tags: # TODO REMOVE after shell runner is disabled
     - sc-swarm
@@ -88,6 +92,7 @@ test:
     curl -sI http://wiki:80 | head -1 | grep -q "200 OK"
 
 check_for_orphan_assets:
+  dependencies: []
   stage: test
   tags: # TODO REMOVE after shell runner is disabled
     - sc-swarm
@@ -142,6 +147,7 @@ check_for_orphan_assets:
 # and commit information.
 
 deploy_preview:
+  dependencies: []
   stage: deploy
   tags: # TODO REMOVE after shell runner is disabled
     - sc-swarm
@@ -160,6 +166,7 @@ deploy_preview:
 # https://sciwiki.fredhutch.org
 
 deploy:
+  dependencies: []
   stage: deploy
   tags: # TODO REMOVE after shell runner is disabled
     - sc-swarm

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,6 +65,7 @@ build:
 
     rm -rf _site && mkdir _site
 
+    echo CI_PROJECT_DIR is $CI_PROJECT_DIR
 
     docker run --rm --name grab-site-files \
       -v "$CI_PROJECT_DIR/_site:/data" \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,13 +61,10 @@ build:
     fi
     # build image
     docker build --build-arg JEKYLL_ENV=$JEKYLL_ENV -t sc-registry.fredhutch.org/wiki:test .
-    # rm -rf _site && mkdir _site
-    echo current directory is
-    pwd
-
+    rm -rf _site && mkdir _site
     docker run --rm --name grab-site-files \
-      -v /builds/FredHutch/wiki:/data sc-registry.fredhutch.org/wiki:test \
-      sh -c "mkdir -p /data/_site && cp -r /usr/share/nginx/html/* /data/_site/"
+      -v $CI_PROJECT_DIR:/data sc-registry.fredhutch.org/wiki:test \
+      sh -c "cp -r /usr/share/nginx/html/* /data/_site/"
     ls -l
     # docker run --rm --name grab-site-files \
     #   -v $(pwd):/data sc-registry.fredhutch.org/wiki:test \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,13 +65,11 @@ build:
 
     rm -rf _site && mkdir _site
 
-    echo CI_PROJECT_DIR is $CI_PROJECT_DIR
-
-    docker run --rm --name grab-site-files \
-      -v "$CI_PROJECT_DIR/_site:/data" \
-      sc-registry.fredhutch.org/wiki:test \
-      sh -c "ls -l /usr/share/nginx/html && cp -r /usr/share/nginx/html/* /data/ && ls -l /data"
-
+    docker create --name grab-site-files sc-registry.fredhutch.org/wiki:test
+    docker cp grab-site-files:/usr/share/nginx/html _site
+    docker rm grab-site-files
+  
+  
     echo "Host-side check of _site:"
     ls -altr _site
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 default:
   before_script:
     - apk update
-    - apk --no-cache add py3-pip python3 curl git jq bash zip
+    - apk --no-cache add py3-pip python3 curl git jq bash
     #- pip install pip==21.3.1 # workaround: https://stackoverflow.com/a/72469586/470769
 
     - pip3 install --break-system-packages pyyaml

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ python3 -m http.server -d html
 
 That will make the site available at the URL `http://localhost:8000`.
 
+Note that build artifacts expire after 2 weeks, at which point they can't be downloaded.
+
 ## Building the site locally
 
 You may want to build a copy of this wiki locally (on your own computer) to make sure that it looks the way you want before pushing your changes.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ To contribute to the Wiki you only need to have your GitHub username added to th
 
 [Repository structure](#repo-structure)
 
+[Viewing rendered changes to non-`main` branches](#viewing-test-builds)
+
 [Building a copy of this Wiki locally](#building-the-site-locally)
 
 [Building a copy of this Wiki on a rhino](#building-the-site-on-rhino)
@@ -171,6 +173,30 @@ You can check what branch and what commit is reflected by going to
 
 
 
+## Viewing Test Builds
+
+There are two ways to view changes to the wiki (that have not been pushed to the `main` branch) without building the site yourself (for that, see the next section).
+
+The first way is to view the [preview site](#automated-deployment). This has some limitations, as described in that link.
+
+The other way is to download a build artifact, which is a zip file containing the static, rendered pages of the site.
+
+These artifacts are only produced when there is a *successful* build of the site on any branch.
+
+You can access the build artifacts [here](https://wiki-artifact-app.fredhutch.org/) (within the Fred Hutch network only).
+This will show recent builds of the CI/CD pipeline, starting with the most recent. It gives information about the commit and who created it. You can download the associated build artifact by clickng "Download static files". This will download a file called `artifact.zip` to your local machine.
+
+Unzip the file. You will see that it contains an `html` directory at the top level.
+
+In order to view the site properly, you must use a web server. if you just try to open the `index.html` file inside the `html` directory in your browser, the site will not render properly.
+
+One easy way to serve the site with a web server is to use Python. If you are in the directory where you downloaded and unzipped `artifact.zip`, you can just run this command:
+
+```bash
+python3 -m http.server -d html
+```
+
+That will make the site available at the URL `http://localhost:8000`.
 
 ## Building the site locally
 


### PR DESCRIPTION
...or you will be able to, once this is merged (right now you can only see artifacts from the `add-artifacts` branch).

What's a build artifact? In this case it is a zip file containing the static, rendered site that was created by the GitLab CI/CD pipeline.

So before, to see how your changes look, you had to use the [preview site](https://sciwiki-preview.fredhutch.org/) which would show you the last non-`main` commit, but this could get overwritten by someone else's commit while you were looking at it. Or you had to build the site locally yourself, which is always a huge pain.

Now you can download a zip file that will show you how the site looks based on your latest commit to any branch. 

Read the changes to the README in this PR to see how it works (it's easy).

Closes #1176 

