### PR TITLE
Fixing links to old HDC content

### DIFF
--- a/_compdemos/nextflow.md
+++ b/_compdemos/nextflow.md
@@ -9,7 +9,7 @@ Other workflow managers that people may recognize are Snakemake, Cromwell and To
 Generally speaking, workflow managers are software tools that make it easier to run complex bioinformatic analyses that involve multiple steps, each of which may invoke a different piece of software with different environmental dependencies or resource requirements. 
 The benefits of a workflow manager like Nextflow is that it should make it easier to run your analysis while transparently managing all of the issues that tend to crop up when running a shell script (missing dependencies, not enough resources, hard to tell where failures are coming from, not easily published or transferred to collaborators).
 
-For more details on Nextflow and workflow managers overall, please visit the workflow documentation available [here](/hdc/hdc_workflows).
+For more details on Nextflow and workflow managers overall, please visit the workflow documentation available [here](/datascience/using_workflows).
 
 ### Example workflows
 Fred Hutch researchers are building and maintaining a set of Nextflow workflows for use by the general community [here](https://github.com/FredHutch/reproducible-workflows/tree/master/nextflow), while also providing an example of how to write your own workflows.

--- a/_datademos/computational_rank.md
+++ b/_datademos/computational_rank.md
@@ -124,7 +124,7 @@ If you want to learn how to write your own WDL files, then we have the [Developi
 
 ### Containers Option 3
 
-Use Nextflow to run your software. Requires knowledge of Nextflow and Nextflow workflows. For more info on running Nextflow at Fred Hutch, [check this link out](https://sciwiki.fredhutch.org/hdc/hdc_workflows/).
+Use Nextflow to run your software. Requires knowledge of Nextflow and Nextflow workflows. For more info on running Nextflow at Fred Hutch, [check this link out](/datascience/using_workflows).
 
 ## 3. Best Practices When Using Conda
 

--- a/_datademos/on_aws.md
+++ b/_datademos/on_aws.md
@@ -78,4 +78,4 @@ If you have any problems using this configuration, please don't hesitate to
 ## Running the workflow
 
 To run a workflow with this configuration, follow the guidance for formatting
-the appropriate [run script](/hdc/workflows/running/run_script).
+the appropriate [run script](/datademos/run_script/).

--- a/_datademos/on_gizmo.md
+++ b/_datademos/on_gizmo.md
@@ -79,7 +79,7 @@ If you have any problems using this configuration, please don't hesitate to
 ## Running the workflow
 
 To run a workflow with this configuration, follow the guidance for formatting
-the appropriate [run script](/hdc/workflows/running/run_script).
+the appropriate [run script](/datademos/run_script).
 
 ## Note: ERROR 151
 

--- a/_datademos/process_resources.md
+++ b/_datademos/process_resources.md
@@ -28,7 +28,7 @@ but it's generally safe to set CPU/RAM values in which either
 
 To specify that all of the processes within a workflow should use
 the same number of CPUs and RAM, a simple pair of arguments can
-be provided [in the run script](/hdc/workflows/running/run_script)
+be provided [in the run script](/datademos/run_script/)
 using the flags:
 
 - `-process.memory`: e.g. "1.GB"
@@ -48,7 +48,7 @@ able to distinguish between light-weight vs. heavy-duty processes.
 
 ### Setting Resources by Process Name
 
-Within the [Nextflow configuration file](/hdc/workflows/workflow_background)
+Within the [Nextflow configuration file](/datademos/workflow_background/)
 that you use to run a particular script, you can add a section which
 sets the amount of CPU/RAM for each individual process _by name_.
 

--- a/_datademos/run_script.md
+++ b/_datademos/run_script.md
@@ -75,8 +75,8 @@ for an added level of reproducibility.
 ## Nextflow Configuration File
 
 Use `NXF_CONFIG` to specify the configuration file used to run workflows either
-[on SLURM/gizmo](/hdc/workflows/running/on_gizmo) or
-[on AWS](/hdc/workflows/running/on_aws).
+[on SLURM/gizmo](/datademos/on_gizmo) or
+[on AWS](/datademos/on_aws).
 
 
 ## Workflow Repository

--- a/_datademos/running_first_workflow.md
+++ b/_datademos/running_first_workflow.md
@@ -18,7 +18,7 @@ or in the AWS cloud.
 You may select which of these options based on:
 - The size of the workflow - small workflow may run quickly on a local machine;
 - The capacity available to your group in SLURM/gizmo and/or AWS or any associated cost;
-- The location of the input data (see [Background on Workflows](/hdc/workflows/workflow_background)).
+- The location of the input data (see [Background on Workflows](/datademos/workflow_background/)).
 
 ## Set up your Nextflow configuration
 
@@ -26,22 +26,22 @@ We recommend that you set up a small "configuration" file which records which ty
 compute resources should be used to execute a workflow.
 
 For example, if you would like to run a workflow on SLURM, then
-[follow this guide](/hdc/workflows/running/on_gizmo) to create a file called
-`nextflow.slurm.config`. Similarly, to [run a workflow on AWS](/hdc/workflows/running/on_aws)
+[follow this guide](/datademos/on_gizmo) to create a file called
+`nextflow.slurm.config`. Similarly, to [run a workflow on AWS](/datademos/on_aws)
 you may create a file called `nextflow.aws.config`.
 
 The appropriate config file can then be reused to specify compute resources
-when running any number of workflows by pointing to it [in the run script](/hdc/workflows/running/run_script).
+when running any number of workflows by pointing to it [in the run script](/datademos/run_script).
 
 ## Pick the workflow you want to run
 
 Depending on your research goals, you may find a workflow which performs the
-needed analysis either [in our workflow catalog](/hdc/workflows/workflow_catalog)
+needed analysis either [in our workflow catalog](/datascience/nextflow_catalog/)
 or in the community-developed [nf-core workflow catalog](https://nf-co.re/pipelines).
 
 Depending on the workflow, you may find it useful to use one of the reference
 databases which have been made available on the shared filesystem
-([more details here](/hdc/hdc_refgenomes/)).
+([more details here](/datascience/refgenomes/)).
 
 If you do not see any useful options available, please don't hesitate to
 [reach out](mailto:sminot@fredhutch.org) so that we can find a solution which
@@ -59,7 +59,7 @@ The "run script" will contain the full `nextflow run ...` command, as well as al
 of the settings and parameters used to run that particular workflow on your particular
 dataset.
 
-Follow [these instructions](/hdc/workflows/running/run_script) for setting up that run script.
+Follow [these instructions](/datademos/run_script) for setting up that run script.
 
 ## Run the workflow
 


### PR DESCRIPTION
## Description
- Some old HDC links stuck around in a few articles, mostly NextFlow related.
- No text change, just pointing them to the new locations for each article.

## Related Issues
- Fixes #1157 

## Testing
- Built locally, links work great.