### PR TITLE
Making PROOF URL more visible in documentation

### DIFF
--- a/_datademos/proof-how-to.md
+++ b/_datademos/proof-how-to.md
@@ -2,6 +2,7 @@
 title: How to Use PROOF
 ---
 
+[proof.fredhutch.org](https://proof.fredhutch.org) on the Fred Hutch Network
 
 **PROOF** (**PR**oduction **O**n-ramp for **O**ptimization and **F**easibility) is a user-friendly tool designed for managing and executing [**WDL**](https://docs.openwdl.org/en/1.0.0/) (Workflow Description Language) workflows using the [**Cromwell**](https://cromwell.readthedocs.io/en/stable/) workflow manager, configured to run on the [**Fred Hutch cluster**](https://sciwiki.fredhutch.org/scicomputing/compute_jobs/). PROOF allows users to:
 

--- a/_datademos/proof-troubleshooting.md
+++ b/_datademos/proof-troubleshooting.md
@@ -2,7 +2,9 @@
 title: PROOF Troubleshooting
 ---
 
-- [PROOF Server](#common-proof-server-issues)
+[proof.fredhutch.org](https://proof.fredhutch.org) on the Fred Hutch Network
+
+- [PROOF Server Issues](#common-proof-server-issues)
 - [Workflow Level Issues](#workflow-level-issues)
 - [Task Level Issues](#task-level-issues)
 - [Execution Issues](#execution-issues)

--- a/_datascience/proof.md
+++ b/_datascience/proof.md
@@ -3,6 +3,8 @@ title: PROOF
 primary_reviewers: vortexing, abbywall
 ---
 
+[proof.fredhutch.org](https://proof.fredhutch.org) on the Fred Hutch Network
+
 **PROOF** (**PR**oduction **O**n-ramp for **O**ptimization and **F**easibility) is a user-friendly tool designed for managing and executing [**WDL**](https://docs.openwdl.org/en/1.0.0/) (Workflow Description Language) workflows using the [**Cromwell**](https://cromwell.readthedocs.io/en/stable/) workflow manager, configured to run on the [**Fred Hutch cluster**](https://sciwiki.fredhutch.org/scicomputing/compute_jobs/). PROOF allows users to:
 
 - Automate all the backend configurations necessary to run your workflows instantly.


### PR DESCRIPTION
## Description
- During recent DaSL courses, @caalo recently noticed that it's not obvious in PROOF documentation where it actually is, i.e. "proof.fredhutch.org" is no where to be found in the text, just a small hyperlink buried in a paragraph.
- Need to make the link more prevalent for new users to try it out, adding it as a subtitle at the top of the page, but open to other configurations as well.

## Related Issues
- Fixes #1181 

## Testing
- Built locally, works as expected.