### PR TITLE
update file name and path

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ build:
     unzip -qq main.zip
     cp easybuild-life-sciences-main/docs/_r/* ./_rModules/
     cp easybuild-life-sciences-main/docs/_python/* ./_pythonModules/
-    cp easybuild-life-sciences-main/docs/bio-modules-18.04.md ./_scicomputing/bio-modules-18.04.md.orig
+    cp easybuild-life-sciences-main/docs/sw_inventory/gizmo-bio-modules-18.04.md ./_scicomputing/bio-modules-18.04.md.orig
     FIRST_BLANK_LINE=$(grep -n -m 1 '^$' ./_scicomputing/bio-modules-18.04.md.orig | cut -d: -f1)
     echo "---" >> ./_scicomputing/bio-modules-18.04.md
     echo "title: Scientific Software BioModules" >> ./_scicomputing/bio-modules-18.04.md


### PR DESCRIPTION
In [9809576](https://github.com/FredHutch/easybuild-life-sciences/commit/98095764ebf40680e17a3a6cce13c1df2085fcbb) of the easybuild repo, a file used by the GitLab pipeline that builds the wiki was moved and renamed. This change should fix the build issue.

