### PR TITLE
Pointing "first-rhino" hyperlinks to other resources

### DIFF
--- a/_compdemos/howtoRhino.md
+++ b/_compdemos/howtoRhino.md
@@ -75,7 +75,7 @@ A useful 'test' of the X forwarding is a simple program invoked with the command
 
 If you want to run a computationally-intensive X/GUI app, you should grab your own node to do so. This will not impact other users of the `rhino` systems. This method can also be used to run non-GUI apps interactively.
 
-"Grab" a node using one of the grab commands, you can read more about how to do this both [here](/compdemos/first_rhino/#logging-on-to-gizmo-via-grabnode) and [here.](/scicomputing/compute_platforms/#gizmo-cluster) Once done, the grab command you used will have created an ssh session to the remote node you have reserved, and you are now ready to run your app. Use the same commands as you would on a rhino (see above).
+"Grab" a node using one of the grab commands, you can read more about how to do this both [here](/compdemos/grabnode/) and [here.](/scicomputing/compute_platforms/#gizmo-cluster) Once done, the grab command you used will have created an ssh session to the remote node you have reserved, and you are now ready to run your app. Use the same commands as you would on a rhino (see above).
 
 
 

--- a/_datademos/running_first_workflow.md
+++ b/_datademos/running_first_workflow.md
@@ -76,5 +76,5 @@ computer on and connected to the internet (if running on AWS).
 If running a workflow on the SLURM, a good option is to use `sbatch` so that the head node
 itself is run as a SLURM job.
 Another good approach is to use [tmux](https://github.com/tmux/tmux/wiki)
-to keep a session open on [a grabbed node](/compdemos/first_rhino/) for running
+to keep a session open on [a grabbed node](/compdemos/grabnode/) for running
 the head node.

--- a/_scicomputing/compute_platforms.md
+++ b/_scicomputing/compute_platforms.md
@@ -19,16 +19,13 @@ Rhino | CLI, FH credentials on campus/VPN off campus | Direct to all local stora
 NoMachine | NX Client, FH credentials on campus/VPN off campus | Direct to all local storage types
 Gizmo | Via Rhino or NoMachine hosts (CLI, FH credentials on campus/VPN off campus) | Direct to all local storage types
 
-If you're new to remote cluster usage, 
-please see [this tutorial](/compdemos/first_rhino/)
-for step-by-step instructions for logging on to `rhino` and `gizmo`,
+If you're new to remote cluster usage, please see [this tutorial](/pathways/path-interactive/) for step-by-step instructions for logging on to `rhino` and `gizmo`.
 
 ### Rhino
 
 `Rhino`, or more specifically the `Rhinos`, are three locally managed HPC servers all accessed via the name `rhino`. Together, they function as a data and compute hub for a variety of data storage resources and high performance computing (HPC) such as those in the table above. The specific guidance for the use of each of the approaches to HPC access are slightly different, but will all require the user to learn how to access and interact with `rhino`.
 
-More information on the topic of ssh configurations for access to `rhino` can be found [here.](/scicomputing/access_methods/)
-More information on specific guidance for using `rhino` are in our Resource Library for [the basics](/compdemos/first_rhino/) and [for more detailed descriptions](/compdemos/howtoRhino/).
+More information on the topic of ssh configurations for access to `rhino` can be found [here](/scicomputing/access_methods/). More information on specific guidance for using `rhino` is in our [Resource Library](/compdemos/howtoRhino/).
 
 
 ### Gizmo Cluster


### PR DESCRIPTION
## Description
- @dtenenba mentioned that the link to the "First Rhino" page wasn't working, turns out we shifted that content elsewhere.
- Rerouting all references of "First Rhino" to interactive session Pathway, access methods, and grabnode articles.

## Related Issues
- Fixes #1156 

## Testing
- Built locally, links work as expected.