### PR TITLE
Update navigation.yml

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -45,7 +45,7 @@ datascience:
       - title: Pathways
         url: /pathways/
       - title: Data Science Training
-        url: /datascience/hutch_courses/
+        url: https://hutchdatascience.org/courses/
   - title: General
     children:
       - title: Tech Hiring for Science


### PR DESCRIPTION
fixing data science training link - points now to https://hutchdatascience.org/courses/