### PR TITLE
Added Callouts

### DIFF
--- a/_includes/callout.html
+++ b/_includes/callout.html
@@ -1,0 +1,7 @@
+<blockquote class="callout callout--{{ include.type | default: 'info' }}">
+  <span class="callout-icon">{{ include.icon | default: 'ℹ️' }}</span>
+  <span class="callout-body">
+    {% if include.title %}<span class="callout-title">{{ include.title }}</span>{% endif %}
+    {{ include.content | markdownify }}
+  </span>
+</blockquote>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -38,3 +38,55 @@ html {
 code.language-plaintext.highlighter-rouge {
   background: #afb8c133; // originally #fafafa
 }
+
+/* Notion-like callouts for Minimal Mistakes */
+blockquote.callout {
+  margin: 1.25rem 0;
+  padding: 0.875rem 1rem;
+  border: 0;
+  border-left: 6px solid #d0d7de;
+  border-radius: 10px;
+  background: #f6f8fa;
+  display: flex;
+  gap: .75rem;
+  align-items: flex-start;
+
+  /* remove default MM blockquote styles */
+  font-style: normal;
+}
+
+blockquote.callout > .callout-icon {
+  font-size: 1.25rem;
+  line-height: 1.25rem;
+  margin-top: .2rem; /* nudge to align with text */
+  flex: 0 0 auto;
+}
+
+blockquote.callout > .callout-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* Title inside callout */
+blockquote.callout .callout-title {
+  font-weight: 700;
+  margin: 0 0 .25rem 0;
+}
+
+/* Variants */
+blockquote.callout--info   { background: #eef6ff; border-left-color: #2b6cb0; }
+blockquote.callout--tip    { background: #ecfdf5; border-left-color: #047857; }
+blockquote.callout--warn   { background: #fff7ed; border-left-color: #c2410c; }
+blockquote.callout--error  { background: #fef2f2; border-left-color: #b91c1c; }
+blockquote.callout--quote  { background: #f6f6ff; border-left-color: #6d28d9; }
+
+blockquote.callout p {
+  margin: 0;            /* tighter paragraph rhythm */
+}
+
+blockquote.callout p + p {
+  margin-top: .5rem;    /* small spacing for multiple paragraphs */
+}
+
+/* Optional: make links stand out a bit */
+blockquote.callout a { text-decoration: underline; }


### PR DESCRIPTION
I've grown to like [Notion Callouts][nc] and [GitHub Alerts][ga] and I would like to use them in the sciwiki articles I am drafting. The following code within articles produced the styling attached:

```
{% capture body %}
Here is a *point* of **information**.
{% endcapture %}
{% include callout.html type="info" icon="🔎" title="Info" content=body %}

{% capture body %}
Find a tip [here]().
{% endcapture %}
{% include callout.html type="tip" icon="💡" title="Tip" content=body %}

{% capture body %}
### The computer broke! 

Maybe don't do that next time. Instead you could:

- Ride a bike
- Go for a walk
- Sing in the shower
{% endcapture %}
{% include callout.html type="error" icon="⛔️" title="Error" content=body %}

{% capture body %}
Here be dragons.
{% endcapture %}
{% include callout.html type="warn" icon="🐉" title="Warn" content=body %}

{% capture body %}
With great power comes great responsibility.
{% endcapture %}
{% include callout.html type="quote" icon="🕷️" title="Quote" content=body %}
```

<img width="673" height="758" alt="Screenshot 2025-08-21 at 12 09 53 PM" src="https://github.com/user-attachments/assets/d07f8512-fbf2-4530-9085-f22f24a67fee" />

[nc]: https://www.notion.com/help/customize-and-style-your-content#callouts
[ga]: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts