### PR TITLE
removed references to atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ When a pull request is made, it automatically requests a pull request review fro
 Please remember to make a [markdown for yourself](https://github.com/FredHutch/wiki/blob/main/contributorTemplate.md) in our `_contributors` directory so that we can give you credit for your contributions publicly on the site if you would like to.  
 
 ## Contributing via an external text editor
-You can also contribute to the wiki from external editors that can interoperate with GitHub. We have had good experience with [Atom](https://github.atom.io/) but other text editors have GitHub integration as well.  Also there is a tutorial on how to use [VSCode](/compdemos/vscode_markdown_howto/) which is what you will want to use if you plan to contribute many screenshots or other images.  
+You can also contribute to the wiki from external editors that can interoperate with GitHub. We
+recommend [VSCode](https://code.visualstudio.com/) because it has good GitHub integration, and we have prepared a VSCode [tutorial](/compdemos/vscode_markdown_howto/) which you should reference if you plan to contribute screenshots or other images.  
 
 ## Wiki Content Style Guide
 ### Github-Flavored Markdown
@@ -96,7 +97,7 @@ If it is a link to an external site use:
 
 
 ### In-text Images
-If you'd like to add images to your entry, some text editors (eg. Atom or VSCode via their respective plugins) allow for copy-and-pasting of images.  You can read some instructions on how to get set up with VSCode in one of the Computing Demo's.  
+If you'd like to add images to your entry, some text editors (eg. VSCode via its respective plugins) allow for copy-and-pasting of images.  You can read some instructions on how to get set up with VSCode in one of the Computing Demo's.  
 
 One edit is that in order for Jekyll to correctly render the images in a page, they should be placed in the `assets` subdirectory of the directory containing the page being edited. The following text is the example format that the call to the image needs to be in for a markdown in the **_compdemos** folder:
 ```
@@ -104,7 +105,7 @@ One edit is that in order for Jekyll to correctly render the images in a page, t
 ```
 If the markdown you are editing is in one of the other folders you'll need to change the `compdemos` string to whatever the text of your folder is; please leave out the underscore at the beginning of the folder name.  
 
-Both Atom and VSCode will make a directory called `assets` in the directory where the markdown is, and then will copy your in-text image file there so you can commit it all to the repo.  
+VSCode will make a directory called `assets` in the directory where the markdown is, and then will copy your in-text image file there so you can commit it all to the repo.  
 
 #### Custom sized images
 If you want to adjust the size of your image, you can add your image using HTML syntax. Be sure to include the `alt` attribute.
@@ -119,9 +120,9 @@ If you want to adjust the size of your image, you can add your image using HTML 
 
 Before linking to external images, consider saving a copy and creating an internal link as outlined [here](#in-text-images). This helps ensure content doesn't break over time.
 
-#### Youtube
+#### YouTube
 
-When linking to videos like screencasts you typically want to show an image screenshot and clicking on that screenshot starts the video. Images of videos are stored at https://img.youtube.com/vi and they use the same video id you find in Youtube URLs, so The Gift of Time is `https://youtu.be/rN7cmb1K2yA`. To embed, insert this into markdown:
+When linking to videos like screencasts you typically want to show an image screenshot and clicking on that screenshot starts the video. Images of videos are stored at https://img.youtube.com/vi and they use the same video id you find in YouTube URLs, so The Gift of Time is `https://youtu.be/rN7cmb1K2yA`. To embed, insert this into markdown:
 
     [![The Gift of Time](https://img.youtube.com/vi/rN7cmb1K2yA/0.jpg)](https://youtu.be/rN7cmb1K2yA "Click to see The Gift of Time")
 
@@ -184,7 +185,7 @@ The other way is to download a build artifact, which is a zip file containing th
 These artifacts are only produced when there is a *successful* build of the site on any branch.
 
 You can access the build artifacts [here](https://wiki-artifact-app.fredhutch.org/) (within the Fred Hutch network only).
-This will show recent builds of the CI/CD pipeline, starting with the most recent. It gives information about the commit and who created it. You can download the associated build artifact by clickng "Download static files". This will download a file called `artifact.zip` to your local machine.
+This will show recent builds of the CI/CD pipeline, starting with the most recent. It gives information about the commit and who created it. You can download the associated build artifact by clicking "Download static files". This will download a file called `artifact.zip` to your local machine.
 
 Unzip the file. You will see that it contains an `html` directory at the top level.
 
@@ -224,7 +225,7 @@ If you have Docker installed, run:
 1. Install Ruby (version 1.9.2 or later).
 **Note**: most modern Mac computers already have Ruby installed. If you still need Ruby,
 it can be found [here](https://www.ruby-lang.org/en/downloads/).
-1. On Mac, install xcode commandline tools `xcode-select --install`
+1. On Mac, install xcode command line tools `xcode-select --install`
 1. You may need to install `bundler`. Type
    `which bundler` to see if it is already
    installed. If nothing is returned, then

--- a/_compdemos/Cromwell.md
+++ b/_compdemos/Cromwell.md
@@ -8,7 +8,7 @@ This page should get you started using using the [Cromwell workflow manager](htt
 Cromwell is a software tool that can be used to coordinate and streamline the actual running of bioinformatic (or other analytic) workflows. It is the software that underlies the Broad Institute's [Terra platform](https://terra.bio/).  It's one of several tools and platforms that are able to run workflows written in the WDL language, including [miniWDL](https://miniwdl.readthedocs.io/en/latest/)from the Chan-Zuckerburg initiative, [DNANexus](https://www.dnanexus.com/), and other emerging tools.  
 
 ### Abstracting Storage and Computing Details
-At the Hutch, we have many resources for data storage, software installations and high performance computing available to researchers, which themselves are evolving.  Using a workflow manager that is configured specifically to the types of data storages available at an institution can provide the benefits of "abstracting" or hiding some degree of the logistics involved with actually accessing those data for use in an analysis from the user.  
+At the Hutch, we have many resources for data storage, software installations and high performance computing available to researchers, which themselves are evolving.  Using a workflow manager that is configured specifically to the types of data storage available at an institution can provide the benefits of "abstracting" or hiding some degree of the logistics involved with actually accessing those data for use in an analysis from the user.  
 
 For instance, beyond data storage in our local file system, researchers now have the ability to store data in AWS S3 storage.  Accessing those data for the purposes of using them in workflows requires slightly different knowledge and mechanisms of retrieval (e.g. knowledge of how to use the AWS CLI).  By providing one configuration (or set of instructions for accessing data) for Cromwell that is tailored to what is available at the Hutch, any individual researcher can use Cromwell as an interface to their data, wherever they may be stored.  This intermediate tool then reduces the amount of time and effort on the part of the researcher in understanding the data storage flavor of the day, allowing them to focus more on their data and their analyses.
 
@@ -61,7 +61,7 @@ This means that individual users can:
 ### Writing Workflows
 The Workflow Description Language, or WDL, is intended to be a relatively easy to read workflow language.  There are other workflow languages and workflow managers that run them, but WDL was/is primarily intended to be shared and interpreted by others that may or may not have experience with any given domain-specific language (like Nextflow).  Writing workflows in WDL, therefore, has a fairly low barrier to entry for those of us new to writing workflows.  The specification of the language is actually open source itself, and more about the language can be [found at the OpenWDL site](https://openwdl.org/).  
 
->From OpenWDL:  The Workflow Description Language (WDL) is a way to specify data processing workflows with a human-readable and -writeable syntax. WDL makes it straightforward to define analysis tasks, chain them together in workflows, and parallelize their execution. The language makes common patterns simple to express, while also admitting uncommon or complicated behavior; and strives to achieve portability not only across execution platforms, but also different types of users. Whether one is an analyst, a programmer, an operator of a production system, or any other sort of user, WDL should be accessible and understandable.
+>From OpenWDL:  The Workflow Description Language (WDL) is a way to specify data processing workflows with a human-readable and -writable syntax. WDL makes it straightforward to define analysis tasks, chain them together in workflows, and parallelize their execution. The language makes common patterns simple to express, while also admitting uncommon or complicated behavior; and strives to achieve portability not only across execution platforms, but also different types of users. Whether one is an analyst, a programmer, an operator of a production system, or any other sort of user, WDL should be accessible and understandable.
 
 The basics of this workflow language includes a similar pattern where you specify workflow inputs, the order of tasks and how they pass data between them, and which files are the outputs of the workflow itself.  Then tasks are constructed in the same WDL file  by naming them and providing similar information.  Here's an example of a task that runs `bwa mem` on an interleaved fastq file using a Fred Hutch docker container.  Notice there are sections for the relevant portions of the task, such as `input` (what files or variables are needed), `command` (or what it should run), `output` (which of the generated files is considered the output of the task), and `runtime` (such as what HPC resources and software should be used for this task).  
 
@@ -99,7 +99,7 @@ task BwaMem {
 ```
 
 
-You can find additional WDL documentation in the wild at the [WDL-docs site](https://wdl-docs.readthedocs.io/en/stable/) and the Data Science Lab's [future WDL 102 class that is under devleopment](https://hutchdatascience.org/FH_WDL102_Workflows/).
+You can find additional WDL documentation in the wild at the [WDL-docs site](https://wdl-docs.readthedocs.io/en/stable/) and the Data Science Lab's [future WDL 102 class that is under development](https://hutchdatascience.org/FH_WDL102_Workflows/).
 
 ### Submitting and Monitoring Workflows
 The real strength of Cromwell in particular, as a workflow manager, is that baked into the tool is the ability to interact with the server via an API.  That means that the language of the server is defined and that you can talk to it via anything that can speak that language.  At the Hutch we currently have three ways to interact with Cromwell servers:
@@ -116,7 +116,7 @@ If you make your GitHub repository public, then that repository can be directly 
 
 ## Cromwell Resources at Fred Hutch
 
-To run your own Cromwell server at the Fred Hutch, a variety of possible configurations tailored to the specific resources at Fred Hutch have been created.  You can get started running Cromwell at Fred Hutch using this [Data Science Lab guide: Developing WDL Workflows](https://hutchdatascience.org/Developing_WDL_Workflows/), and there are example workflows to get you started [in this GitHub repo](https://github.com/FredHutch/wdl-test-workflows) and the wider list of Fred Hutch WDL workflwo repo's(https://github.com/fredhutch?q=wdl&type=all&language=&sort=). There is also an associated R package called [fh.wdlR](https://github.com/FredHutch/fh.wdlR) should you want to interact with your server primarily from your desktop R/RStudio.  
+To run your own Cromwell server at the Fred Hutch, a variety of possible configurations tailored to the specific resources at Fred Hutch have been created.  You can get started running Cromwell at Fred Hutch using this [Data Science Lab guide: Developing WDL Workflows](https://hutchdatascience.org/Developing_WDL_Workflows/), and there are example workflows to get you started [in this GitHub repo](https://github.com/FredHutch/wdl-test-workflows) and the wider list of Fred Hutch WDL workflow repo's(https://github.com/fredhutch?q=wdl&type=all&language=&sort=). There is also an associated R package called [fh.wdlR](https://github.com/FredHutch/fh.wdlR) should you want to interact with your server primarily from your desktop R/RStudio.  
 
 Other public GitHub repositories containing WDL or Cromwell related content at the Fred Hutch can be found [via this link to search results](https://github.com/FredHutch?utf8=%E2%9C%93&q=wdl+OR+cromwell&type=&language=) and also the [Fred Hutch Workflow Manager GitHub Project](https://github.com/orgs/FredHutch/projects/8) is a resource that is intended to be a collection of links for either of the two Fred Hutch workflow managers that Sam Minot and Amy Paguirigan will be maintaining.  
 
@@ -137,8 +137,7 @@ If you are using Cromwell with containers, there some Docker containers suitable
 
 ## Additional WDL Resources
 
-These plugins help when you are editing your workflow in Atom or VS Code by color coding and finding errors:
-- [WDL Viewer Package](https://atom.io/packages/atom-wdl-viewer) for Atom
+There are plugins available to help when you are editing your workflow in VS Code by color coding and finding errors:
 - [WDL Syntax Highlighter](https://marketplace.visualstudio.com/items?itemName=broadinstitute.wdl) for VS Code
 
 These relate to the WDL workflow language itself and example workflows to start from:

--- a/_compdemos/git_tips.md
+++ b/_compdemos/git_tips.md
@@ -74,7 +74,7 @@ Since GitHub "sees" the rename of the branch as simply a new branch, it is neces
 
 You will want to ensure that all repository contributors are aware of what's happening and know what steps to take to make sure their work is not disrupted.
 
-Contributors with "push" rights will be able to ressurect the old branch- even unintentionally- by pushing changes to the old name.  Ensure that they have pulled changes (which should update the HEAD reference), merged any local changes from the old branch to the new, and deleted the old branch.  In the example (changing `master` to `main`) the steps would look like:
+Contributors with "push" rights will be able to resurrect the old branch- even unintentionally- by pushing changes to the old name.  Ensure that they have pulled changes (which should update the HEAD reference), merged any local changes from the old branch to the new, and deleted the old branch.  In the example (changing `master` to `main`) the steps would look like:
 
 ```
 git pull
@@ -142,10 +142,6 @@ but does require general knowledge of version control to use effectively.
 Additionally, IDEs (integrated development environments) provide the ability to work with Git while coding:
 - [RStudio](https://rstudio.com/products/rstudio/download/) is an IDE primarily for coding in R.
 Information on its integration with git is available [here](https://support.rstudio.com/hc/en-us/articles/200532077-Version-Control-with-Git-and-SVN).
-- [Atom](https://atom.io) is an IDE
-useful for working with multiple programming languages,
-and has optional packages to support Git.
-More information on the main package can be found [here](https://atom.io/packages/git-gui).
 - [Visual Studio Code](https://code.visualstudio.com) is an IDE also capable of handling multiple programming languages,
 and is the preferred interface for the Hutch's Scientific Computing group.
 A description of its Git interface is available [here](https://code.visualstudio.com/docs/editor/versioncontrol).
@@ -158,7 +154,7 @@ Information on JupyterLab's extension for Git is [here](https://github.com/jupyt
 more info on specific use in relation to Python is [here](/scicomputing/software_python/#using-jupyter-on-rhino).
 
 ## To Fork or Not to Fork?
-What a question!  Different GitHub repositories will have different procedures for how to contribute to them.  Ideally these procedures are outlined in the README or in the CONTIBUTING markdowns inside the repository itself, though sometimes they are less well documented.  When a GitHub repository is created, you have the option to allow or disallow forking (the default is currently to allow forking).  You also can limit who can make a branch on the repository and additional branch/user access limitations via options in the Settings tab, for `Managing Access` or `Branches`.  There are many options to control how users can interact with a repo that are far too extensive to discuss here.  
+What a question!  Different GitHub repositories will have different procedures for how to contribute to them.  Ideally these procedures are outlined in the README or in the CONTRIBUTING markdowns inside the repository itself, though sometimes they are less well documented.  When a GitHub repository is created, you have the option to allow or disallow forking (the default is currently to allow forking).  You also can limit who can make a branch on the repository and additional branch/user access limitations via options in the Settings tab, for `Managing Access` or `Branches`.  There are many options to control how users can interact with a repo that are far too extensive to discuss here.  
 
 ### Fork!  
 When a user forks a repo, it creates a duplicate repository that is administered by the user themselves and shows up in their own user's list of repo's.  This allows the user to make any changes desired on their own version of the repo but then requires a pull request from the forked repo TO the original repo in order to contribute any commits back to the original repo. Reasons you would want to fork a repo include:


### PR DESCRIPTION
[Atom is no longer receiving security updates](https://github.blog/news-insights/product-news/sunsetting-atom/), so I do not think we should recommend that people use it. Also fixed typos on pages where there were references to Atom.