### PR TITLE
removed _data from include in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -101,7 +101,6 @@ footer:
 
 # Reading Files
 include:
-  - _data
   - assets
 
 exclude:


### PR DESCRIPTION
Pages in collections were being rendered twice in two different locations, one with a leading underscore in the name of the collection, and one without. See for example:

- https://sciwiki.fredhutch.org/datademos/dmptool/
- https://sciwiki.fredhutch.org/_datademos/dmptool/

Claude and I had a chat about why this might be the case, and apparently including any directory with a leading underscore in `include` make everything in directories with underscores get rendered twice. I don't know if I buy this explanation, but locally it does solve the issue for me, in the sense that `/datademos/dmptool/` is rendered, and `/_datademos/dmptool/` is not.

I run this locally with `./build.sh`