### PR TITLE
Fix "Updated:" date showing the wrong date on wiki pages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,8 @@ stages:
 
 build:
   stage: build
+  variables:
+    GIT_DEPTH: 0
   tags: # TODO REMOVE after shell runner is disabled
     - sc-swarm
   artifacts:


### PR DESCRIPTION
### Problem

The "Updated:" date at the bottom of most wiki pages shows the date of the last commit to the entire repo, rather than the date the specific page was last modified.

### Root Cause

The wiki uses the [`jekyll-last-modified-at`](https://github.com/gjtorikian/jekyll-last-modified-at) plugin to determine each page's last-modified date. This plugin works by running `git log -n 1 --format="%ct" -- <path>` to find the most recent commit that touched a given file.

The Jekyll build runs inside a Docker container, and the `.git` directory is copied into the image via the Dockerfile's `ADD` command. However, GitLab CI performs a **shallow clone** by default (limited commit history). With a shallow clone, git sees the single available commit as having introduced every file, so `git log -n 1 -- <any-file>` returns the same date for all pages — the date of the most recent commit to the repo.

### Fix

Added `GIT_DEPTH: 0` to the `build` job in `.gitlab-ci.yml`. This tells GitLab CI to perform a deep clone, giving the `jekyll-last-modified-at` plugin access to the complete git history so it can correctly determine the last commit that touched each individual file.
