### PR TITLE
Add tips for adding WDL pipelines to Cirro

### DIFF
--- a/_datascience/cirro.md
+++ b/_datascience/cirro.md
@@ -108,7 +108,7 @@ can be found [in the Cirro documentation](https://docs.cirro.bio/pipelines/addin
 - Many WILDS WDL Library [pipelines](https://github.com/getwilds/wilds-wdl-library/tree/main/pipelines) are integrated with Cirro, and you can use these as examples
 - Your WDL must be able to handle AWS S3 URIs
 - Your WDL must not use `ftp` for file transfer (`http` is ok)
-- Your WDL must not use a Docker image that is based on Alpine Linux (Ubunut is ok)
+- Your WDL must not use a Docker image that is based on Alpine Linux (Ubuntu is ok)
 
 If you'd like to contribute your WDL to the WILDS WDL Library, we provide Cirro validation automatically. The validation checks that all required files are present (`preprocess.py`, `process-form.json`, `process-input.json`, `process-output.json`, `process-compute.config`), JSON files are valid, and `preprocess.py` has no syntax errors. You can run this locally with `make lint_cirro` from within the cloned GitHub repo. Reach out to us at `wilds at fredhutch.org`.
 

--- a/_datascience/cirro.md
+++ b/_datascience/cirro.md
@@ -110,7 +110,7 @@ can be found [in the Cirro documentation](https://docs.cirro.bio/pipelines/addin
 - Your WDL must not use `ftp` for file transfer (`http` is ok)
 - Your WDL must not use a Docker image that is based on Alpine Linux (Ubunut is ok)
 
-If you'd like to contribute your WDL to the WILDS WDL Library, we provide Cirro validation automatically. The validation checks that all required files are present (`preprocess.py`, `process-form.json`, `process-input.json`, `process-output.json`, `process-compute.config`), JSON files are valid, and `preprocess.py` has no syntax errors. You can run this locally with `make lint_cirro` from within the cloned GitHub repo. Reach out to us at wilds@fredhutch.org.
+If you'd like to contribute your WDL to the WILDS WDL Library, we provide Cirro validation automatically. The validation checks that all required files are present (`preprocess.py`, `process-form.json`, `process-input.json`, `process-output.json`, `process-compute.config`), JSON files are valid, and `preprocess.py` has no syntax errors. You can run this locally with `make lint_cirro` from within the cloned GitHub repo. Reach out to us at `wilds at fredhutch.org`.
 
 
 **Need Help?**  

--- a/_datascience/cirro.md
+++ b/_datascience/cirro.md
@@ -103,6 +103,16 @@ including official repositories from projects like GATK.
 Guidance on adding an existing WDL or Nextflow workflow to Cirro
 can be found [in the Cirro documentation](https://docs.cirro.bio/pipelines/adding-pipelines/).
 
+**Tips for adding WDL workflows to Cirro**
+
+- Many WILDS WDL Library [pipelines](https://github.com/getwilds/wilds-wdl-library/tree/main/pipelines) are integrated with Cirro, and you can use these as examples
+- Your WDL must be able to handle AWS S3 URIs
+- Your WDL must not use `ftp` for file transfer (`http` is ok)
+- Your WDL must not use a Docker image that is based on Alpine Linux (Ubunut is ok)
+
+If you'd like to contribute your WDL to the WILDS WDL Library, we provide Cirro validation automatically. The validation checks that all required files are present (`preprocess.py`, `process-form.json`, `process-input.json`, `process-output.json`, `process-compute.config`), JSON files are valid, and `preprocess.py` has no syntax errors. You can run this locally with `make lint_cirro` from within the cloned GitHub repo. Reach out to us at wilds@fredhutch.org.
+
+
 **Need Help?**  
 Need help using the Cirro platform for data management and analysis?
 Drop-in office hours with the Cirro team will be held every Tuesday at 2pm.


### PR DESCRIPTION
This PR adds some high-level tips for folks wanting to add a custom WDL to Cirro. It also plugs the WILDS WDL Library as a resource for this.