### PR TITLE
change jupyter --ip flag value to 0.0.0.0

### DIFF
--- a/_scicomputing/software_R.md
+++ b/_scicomputing/software_R.md
@@ -177,7 +177,7 @@ You will be using Jupyter Lab, not Jupyter Notebook. This should not be a proble
 To start Jupyter Lab, run this command:
 
 ```
-jupyter lab --ip=$(hostname) --port=$(fhfreeport) --no-browser
+jupyter lab --ip=0.0.0.0 --port=$(fhfreeport) --no-browser
 ```
 
 This command will spit out several URLs.

--- a/_scicomputing/software_python.md
+++ b/_scicomputing/software_python.md
@@ -87,7 +87,7 @@ After you have connected to `rhino`, run these commands:
 ```
     username@rhino01:~$ ml purge
     username@rhino01:~$ ml JupyterLab/4.0.3-GCCcore-12.2.0  Seaborn/0.12.2-foss-2022b scikit-learn/1.2.1-gfbf-2022b
-    username@rhino01:~$ jupyter lab --ip=$(hostname) --port=$(fhfreeport) --no-browser
+    username@rhino01:~$ jupyter lab --ip=0.0.0.0 --port=$(fhfreeport) --no-browser
 ```
 
 You will see output like this:


### PR DESCRIPTION
We were telling people to start jupyter lab with `--ip=$(hostname)` which somehow worked, even though it shouldn't have. That flag is about what network interface to bind to, not what the hostname is.

Something changed and we got a couple of reports of this no longer working and the fix was to change `$(hostname)` to `0.0.0.0`.

