### PR TITLE
Replace stale WILDS WDL/Docker library lists with links to GitHub

### DIFF
--- a/_datascience/wilds_docker.md
+++ b/_datascience/wilds_docker.md
@@ -26,7 +26,7 @@ Docker containers package software with all its dependencies into a standardized
 For bioinformatics workflows, containers are essential for reproducibility—they ensure your analysis produces the same results regardless of where it runs.
 
 ## Available Pre-made Container Images
-The library includes dozens of Docker images for popular bioinformatics tools, spanning alignment, variant calling, structural variants, single-cell analysis, RNA-seq, deep learning, and more. New tools are added regularly, so rather than duplicate that list here (and have it go stale), browse the current set directly:
+The library includes dozens of Docker images for popular bioinformatics tools, spanning alignment (BWA, STAR), variant calling (GATK, BCFtools), structural variants (Manta, DELLY), single-cell analysis (Cell Ranger, Scanpy), RNA-seq (DESeq2, Salmon), deep learning (Flax, RTorch), and more. New tools are added regularly, so rather than duplicate that list here (and have it go stale), browse the current set directly:
 
 - [**Browse all available images on Docker Hub**](https://hub.docker.com/u/getwilds)
 - [**View Dockerfiles and tool directories on GitHub**](https://github.com/getwilds/wilds-docker-library)

--- a/_datascience/wilds_docker.md
+++ b/_datascience/wilds_docker.md
@@ -26,86 +26,12 @@ Docker containers package software with all its dependencies into a standardized
 For bioinformatics workflows, containers are essential for reproducibility—they ensure your analysis produces the same results regardless of where it runs.
 
 ## Available Pre-made Container Images
-The library includes 48+ Docker images for popular bioinformatics tools:
+The library includes dozens of Docker images for popular bioinformatics tools, spanning alignment, variant calling, structural variants, single-cell analysis, RNA-seq, deep learning, and more. New tools are added regularly, so rather than duplicate that list here (and have it go stale), browse the current set directly:
 
-**Alignment & Mapping**
-- **BWA** (`getwilds/bwa`) - Burrows-Wheeler Aligner for DNA sequences
-- **STAR** (`getwilds/star`) - RNA-seq aligner with two-pass methodology
-- **HISAT2** (`getwilds/hisat2`) - Graph-based alignment for RNA-seq
+- [**Browse all available images on Docker Hub**](https://hub.docker.com/u/getwilds)
+- [**View Dockerfiles and tool directories on GitHub**](https://github.com/getwilds/wilds-docker-library)
 
-**Variant Calling & Analysis**
-- **GATK** (`getwilds/gatk`) - Genome Analysis Toolkit for variant discovery
-- **BCFtools** (`getwilds/bcftools`) - VCF/BCF file manipulation and calling
-- **Strelka** (`getwilds/strelka`) - Small variant calling for germline and somatic variants
-- **VarScan** (`getwilds/varscan`) - Variant detection in massively parallel sequencing
-- **GLIMPSE2** (`getwilds/glimpse2`) - Low-coverage whole genome sequencing imputation
-
-**Structural Variants**
-- **Manta** (`getwilds/manta`) - Structural variant and indel discovery
-- **DELLY** (`getwilds/delly`) - Integrated structural variant prediction
-- **Smoove** (`getwilds/smoove`) - SV calling and genotyping wrapper
-
-**Variant Annotation**
-- **ANNOVAR** (`getwilds/annovar`) - Functional annotation of genetic variants
-- **AnnotSV** (`getwilds/annotsv`) - Structural variant annotation and ranking
-
-**Copy Number Analysis**
-- **CNVkit** (`getwilds/cnvkit`) - Copy number variation detection from targeted DNA sequencing
-- **ichorCNA** (`getwilds/ichorcna`) - Tumor fraction and copy number alteration detection
-- **HMMcopy** (`getwilds/hmmcopy`) - Copy number prediction with correction for GC and mappability
-
-**SAM/BAM/CRAM Utilities**
-- **Samtools** (`getwilds/samtools`) - Reading, writing, and manipulating SAM files
-- **Picard** (`getwilds/picard`) - Java tools for manipulating high-throughput sequencing data
-- **biobambam2** (`getwilds/biobambam2`) - Tools for BAM file processing
-
-**Single-Cell Analysis**
-- **Cell Ranger** (`getwilds/cellranger`) - 10x Genomics single-cell analysis pipeline
-- **Scanpy** (`getwilds/scanpy`) - Single-cell analysis in Python
-- **scvi-tools** (`getwilds/scvi-tools`) - Deep generative models for single-cell omics
-
-**RNA-Seq & Expression**
-- **DESeq2** (`getwilds/deseq2`) - Differential gene expression analysis
-- **Salmon** (`getwilds/salmon`) - Transcript quantification
-- **RNA-SeQC** (`getwilds/rnaseqc`) - RNA-seq quality control metrics
-- **RSeQC** (`getwilds/rseqc`) - RNA-seq quality control package
-- **combine-counts** (`getwilds/combine-counts`) - Combine count matrices from multiple samples
-
-**Alternative Splicing**
-- **rMATS-turbo** (`getwilds/rmats-turbo`) - Alternative splicing analysis
-- **JCAST** (`getwilds/jcast`) - Alternative splicing proteomics
-
-**Sequence Quality Control**
-- **FastQC** (`getwilds/fastqc`) - Sequence quality control
-
-**Metagenomics & Assembly**
-- **MEGAHIT** (`getwilds/megahit`) - Ultra-fast metagenome assembler
-- **SPAdes** (`getwilds/spades`) - Genome assembler
-- **DIAMOND** (`getwilds/diamond`) - Accelerated BLAST-compatible sequence aligner
-
-**Deep Learning & Machine Learning**
-- **python-dl** (`getwilds/python-dl`) - Python deep learning environment
-- **RTorch** (`getwilds/rtorch`) - R interface to PyTorch
-
-**Data Access & Utilities**
-- **SRA-tools** (`getwilds/sra-tools`) - NCBI Sequence Read Archive toolkit
-- **ENA-tools** (`getwilds/ena-tools`) - ENA FTP downloader
-- **GDC-client** (`getwilds/gdc-client`) - TCGA GDC Data Transfer Tool
-- **AWS CLI** (`getwilds/awscli`) - Amazon Web Services command line interface
-
-**Genomic Interval & BED Tools**
-- **BEDtools** (`getwilds/bedtools`) - Genome arithmetic and interval operations
-- **BEDOPS** (`getwilds/bedops`) - High-performance genomic interval operations toolkit
-- **bedparse** (`getwilds/bedparse`) - Python module and CLI tool for BED file operations
-
-**Specialized Tools**
-- **UMI-tools** (`getwilds/umi-tools`) - Tools for handling Unique Molecular Identifiers
-- **sourmash** (`getwilds/sourmash`) - k-mer analysis for genomic comparisons
-- **ShapeMapper** (`getwilds/shapemapper`) - RNA structure mapping analysis
-- **gtf-smash** (`getwilds/gtf-smash`) - GTF file manipulation
-- **consensus** (`getwilds/consensus`) - Consensus sequence generation
-
-[Browse all available images on Docker Hub →](https://hub.docker.com/u/getwilds) | [View Dockerfiles on GitHub →](https://github.com/getwilds/wilds-docker-library)
+Each tool's directory on GitHub includes a README with usage examples, available versions, and platform support.
 
 
 ## Key Features of our Pre-made Container Images
@@ -239,12 +165,9 @@ Docker Hub provides more robust infrastructure for container distribution and is
 
 **Do these containers work on Apple Silicon (M1/M2/M3) Macs or ARM-based systems?**
 
-Most WILDS Docker images support both linux/amd64 (Intel/AMD) and linux/arm64 (ARM) architectures, so they'll work natively on Apple Silicon Macs and ARM-based HPC systems. However, some tools have platform-specific limitations:
+Most WILDS Docker images support both linux/amd64 (Intel/AMD) and linux/arm64 (ARM) architectures, so they'll work natively on Apple Silicon Macs and ARM-based HPC systems. However, some tools have platform-specific limitations due to architecture-specific code optimizations, compilation issues, or build resource constraints.
 
-**AMD64-only images** (won't run natively on ARM):
-- BWA, Cell Ranger, DESeq2, DIAMOND, GLIMPSE2, HISAT2, Manta, MEGAHIT, python-dl, rMATS-turbo, RTorch, scvi-tools, ShapeMapper, Smoove, SPAdes, SRA-tools, Strelka
-
-These limitations are due to architecture-specific code optimizations, compilation issues, or build resource constraints. Each tool's README includes a "Platform Availability" section when restrictions apply. Docker Desktop on Apple Silicon can run AMD64 images through emulation, though with reduced performance.
+The current list of AMD64-only tools is tracked in [`amd64_only_tools.txt`](https://github.com/getwilds/wilds-docker-library/blob/main/amd64_only_tools.txt) in the repository. Each affected tool's README also includes a "Platform Availability" section noting the restriction. Docker Desktop on Apple Silicon can run AMD64 images through emulation, though with reduced performance.
 
 For ARM-specific support requests, file an [issue](https://github.com/getwilds/wilds-docker-library/issues) or contact [wilds@fredhutch.org](mailto:wilds@fredhutch.org).
 
@@ -270,14 +193,10 @@ The library uses GitHub Actions to maintain quality and security:
 
 ## Release Notes
 
-**February 2026 - WILDS Docker Library v0.1.0**
-- 48+ bioinformatics tools with multiple versions
-- Automated monthly security scanning with Docker Scout
-- Dual distribution via Docker Hub and GitHub Container Registry
-- Full integration with WILDS WDL Library
-- Automated build and publishing workflows
-- Comprehensive vulnerability reporting
-- Standardized Dockerfile linting and quality checks
+For detailed release notes, see the [WILDS Docker Library releases page on GitHub](https://github.com/getwilds/wilds-docker-library/releases):
+
+- [v0.2.0](https://github.com/getwilds/wilds-docker-library/releases/tag/v0.2.0) - July 2026
+- [v0.1.0](https://github.com/getwilds/wilds-docker-library/releases/tag/v0.1.0) - February 2026
 
 ## Resources
 

--- a/_datascience/wilds_docker.md
+++ b/_datascience/wilds_docker.md
@@ -193,10 +193,8 @@ The library uses GitHub Actions to maintain quality and security:
 
 ## Release Notes
 
-For detailed release notes, see the [WILDS Docker Library releases page on GitHub](https://github.com/getwilds/wilds-docker-library/releases):
+For detailed release notes, see the [WILDS Docker Library releases page on GitHub](https://github.com/getwilds/wilds-docker-library/releases).
 
-- [v0.2.0](https://github.com/getwilds/wilds-docker-library/releases/tag/v0.2.0) - July 2026
-- [v0.1.0](https://github.com/getwilds/wilds-docker-library/releases/tag/v0.1.0) - February 2026
 
 ## Resources
 

--- a/_datascience/wilds_wdl.md
+++ b/_datascience/wilds_wdl.md
@@ -141,7 +141,7 @@ Then you can provide custom inputs using an `inputs.json` file:
 
 The library now includes dozens of modules and pipelines, growing regularly as new tools and workflows are contributed. Rather than duplicate that list here (and have it go stale), browse the current set directly on GitHub:
 
-- [**Modules**](https://github.com/getwilds/wilds-wdl-library/tree/main/modules) - tool-specific, reusable WDL tasks (e.g., BWA, GATK, STAR, SRA download, structural variant callers)
+- [**Modules**](https://github.com/getwilds/wilds-wdl-library/tree/main/modules) - tool-specific, reusable WDL tasks for alignment (BWA, STAR), variant calling (GATK, BCFtools), structural variants (Manta, DELLY), and more
 - [**Pipelines**](https://github.com/getwilds/wilds-wdl-library/tree/main/pipelines) - complete workflows combining multiple modules, from basic educational examples to advanced production pipelines
 
 Each module and pipeline folder includes its own README with usage details, container information, and testing status.

--- a/_datascience/wilds_wdl.md
+++ b/_datascience/wilds_wdl.md
@@ -198,11 +198,8 @@ Contact the WILDS team at [wilds@fredhutch.org](mailto:wilds@fredhutch.org), sch
 
 ## Release Notes
 
-For detailed release notes, see the [WILDS WDL Library releases page on GitHub](https://github.com/getwilds/wilds-wdl-library/releases):
+For detailed release notes, see the [WILDS WDL Library releases page on GitHub](https://github.com/getwilds/wilds-wdl-library/releases).
 
-- [v0.3.0](https://github.com/getwilds/wilds-wdl-library/releases/tag/v0.3.0) - July 2026
-- [v0.2.0](https://github.com/getwilds/wilds-wdl-library/releases/tag/v0.2.0) - March 2026
-- [v0.1.0](https://github.com/getwilds/wilds-wdl-library/releases/tag/v0.1.0) - January 2026
 
 ## Resources
 

--- a/_datascience/wilds_wdl.md
+++ b/_datascience/wilds_wdl.md
@@ -139,42 +139,14 @@ Then you can provide custom inputs using an `inputs.json` file:
 
 ## Available WDLs
 
-> For the most current list of modules and pipelines, see the [WILDS WDL Library GitHub](https://github.com/getwilds/wilds-wdl-library).
+The library now includes dozens of modules and pipelines, growing regularly as new tools and workflows are contributed. Rather than duplicate that list here (and have it go stale), browse the current set directly on GitHub:
 
-### Modules
+- [**Modules**](https://github.com/getwilds/wilds-wdl-library/tree/main/modules) - tool-specific, reusable WDL tasks (e.g., BWA, GATK, STAR, SRA download, structural variant callers)
+- [**Pipelines**](https://github.com/getwilds/wilds-wdl-library/tree/main/pipelines) - complete workflows combining multiple modules, from basic educational examples to advanced production pipelines
 
-| Module | Tool | Container | Description |
-|--------|------|-----------|-------------|
-| [`ww-annovar`](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-annovar) | Variant Annotator | `getwilds/annovar:GRCh38` | Annotate genetic variants with ANNOVAR |
-| [`ww-annotsv`](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-annotsv) | Structural Variant Annotator | `getwilds/annotsv:3.4.4` | Annotate structural variants with AnnotSV |
-| [`ww-aws-sso`](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-aws-sso) | AWS Operations | `getwilds/awscli:2.27.49` | AWS S3 operations with SSO and temporary credential support |
-| [`ww-bcftools`](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-bcftools) | Utilities for Variant Calls | `getwilds/bcftools:1.19` | Call and analyze variants with BCFtools |
-| [`ww-bedtools`](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-bedtools) | Utilities for Genomic Intervals | `getwilds/bedtools:2.31.1` | Work with genomic intervals |
-| [`ww-bwa`](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-bwa) | BWA Aligner | `getwilds/bwa:0.7.17` | Alignment with the Burrows-Wheeler Aligner |
-| [`ww-delly`](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-delly) | Structural Variant Caller | `getwilds/delly:1.2.9` | Call structural variants with Delly |
-| [`ww-gatk`](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-gatk) | GATK Variant Calling | `getwilds/gatk:4.6.1.0` | Variant calling and processing with GATK |
-| [`ww-ichorcna`](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-ichorcna) | Tumor Fraction Estimator | `getwilds/ichorcna:0.2.0` | Estimate tumor fraction with ichorCNA |
-| [`ww-manta`](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-manta) | Structural Variant Caller | `getwilds/manta:1.6.0` | Call structural variants with Manta |
-| [`ww-samtools`](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-samtools) | Utilities for SAM/BAM/CRAM Files | `getwilds/samtools:1.11` | Work with Sequence Alignment/Map (SAM) format files |
-| [`ww-smoove`](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-smoove) | Structural Variant Caller | `brentp/smoove:latest` | Call structural variants with Smoove |
-| [`ww-sra`](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-sra) | SRA Toolkit | `getwilds/sra-tools:3.1.1` | Download sequencing data from NCBI SRA |
-| [`ww-star`](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-star) | STAR Aligner | `getwilds/star:2.7.6a` | RNA-seq alignment with two-pass methodology |
-| [`ww-testdata`](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-testdata) | Test Data Downloader | `getwilds/awscli:2.27.49` | Download reference genomes and test datasets |
+Each module and pipeline folder includes its own README with usage details, container information, and testing status.
 
-### Pipelines
-
-| Pipeline | Complexity | Modules Used | Description |
-|----------|------------|--------------|-------------|
-| [`ww-bwa-gatk`](https://github.com/getwilds/wilds-wdl-library/tree/main/pipelines/ww-bwa-gatk) | Basic | `ww-bwa`, `ww-gatk` | DNA alignment and variant calling |
-| [`ww-ena-star`](https://github.com/getwilds/wilds-wdl-library/tree/main/pipelines/ww-ena-star) | Basic | `ww-ena`, `ww-star` | ENA download and RNA-seq alignment |
-| [`ww-fastq-to-cram`](https://github.com/getwilds/wilds-wdl-library/tree/main/pipelines/ww-fastq-to-cram) | Basic | `ww-bwa`, `ww-samtools` | FASTQ to CRAM conversion |
-| [`ww-sra-salmon`](https://github.com/getwilds/wilds-wdl-library/tree/main/pipelines/ww-sra-salmon) | Basic | `ww-sra`, `ww-salmon` | SRA download and transcript quantification |
-| [`ww-sra-star`](https://github.com/getwilds/wilds-wdl-library/tree/main/pipelines/ww-sra-star) | Basic | `ww-sra`, `ww-star` | SRA download and RNA-seq alignment |
-| [`ww-star-deseq2`](https://github.com/getwilds/wilds-wdl-library/tree/main/pipelines/ww-star-deseq2) | Intermediate | `ww-star`, `ww-deseq2` | RNA-seq alignment and differential expression |
-| [`ww-saturation`](https://github.com/getwilds/wilds-wdl-library/tree/main/pipelines/ww-saturation) | Intermediate | Multiple | Sequencing saturation analysis |
-| [`ww-leukemia`](https://github.com/getwilds/wilds-wdl-library/tree/main/pipelines/ww-leukemia) | Advanced | Multiple | Consensus variant calling for targeted DNA sequencing |
-
-If there's a tool you'd like to see or a task you want written, you can file an [issue](https://github.com/getwilds/wilds-wdl-library/issues), reach out to us directly ([see below](#resources)), or make a [contribution](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md)
+If there's a tool you'd like to see or a task you want written, you can file an [issue](https://github.com/getwilds/wilds-wdl-library/issues), reach out to us directly ([see below](#resources)), or make a [contribution](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md).
 
 
 ## Key Features of the WILDS WDL Library

--- a/_datascience/wilds_wdl.md
+++ b/_datascience/wilds_wdl.md
@@ -226,15 +226,11 @@ Contact the WILDS team at [wilds@fredhutch.org](mailto:wilds@fredhutch.org), sch
 
 ## Release Notes
 
-**January 2026 - WILDS WDL Library v0.1.0**
-- Two-tier architecture with modules and pipelines
-- Pipelines include complexity levels (Basic, Intermediate, Advanced) to guide users
-- Comprehensive automated testing with multiple WDL executors
-- Standardized container management through the WILDS Docker Library
-- Full compatibility with the Fred Hutch PROOF platform
-- 17+ tested modules covering essential bioinformatics tools
-- 8 pipelines covering common bioinformatics workflows including RNA-seq and variant calling
-- All pipelines include zero-configuration test workflows for quick demonstrations
+For detailed release notes, see the [WILDS WDL Library releases page on GitHub](https://github.com/getwilds/wilds-wdl-library/releases):
+
+- [v0.3.0](https://github.com/getwilds/wilds-wdl-library/releases/tag/v0.3.0) - July 2026
+- [v0.2.0](https://github.com/getwilds/wilds-wdl-library/releases/tag/v0.2.0) - March 2026
+- [v0.1.0](https://github.com/getwilds/wilds-wdl-library/releases/tag/v0.1.0) - January 2026
 
 ## Resources
 

--- a/_datascience/wilds_workflow_dev.md
+++ b/_datascience/wilds_workflow_dev.md
@@ -1,5 +1,5 @@
 ---
-title: WILDS Workflow Development Program
+title: WILDS WDL Development Program
 main_authors: tefirman
 ---
 


### PR DESCRIPTION
## Summary
- Corrects the title of the WILDS WDL Development Program page, previously mislabeled "WILDS Workflow Development Program"
- WILDS WDL Library page: replaces inline Release Notes with links to GitHub releases (adds v0.2.0, v0.3.0), and replaces the stale module/pipeline tables (15/8 listed vs. 55/14 actual) with links to the live `modules/` and `pipelines/` folders
- WILDS Docker Library page: replaces the stale container image list (~48 listed vs. ~68 actual), the hardcoded AMD64-only tools list, and the single-release Release Notes section (adds v0.2.0) with links to their corresponding GitHub sources
- All changes trade hand-maintained lists for links to sources that are already kept current, removing ongoing wiki maintenance burden
- Built locally, looks great and links work as expected.