### PR TITLE
Using Modules with popular tools

### DIFF
--- a/_scicomputing/compute_environments.md
+++ b/_scicomputing/compute_environments.md
@@ -123,7 +123,16 @@ See [R and RStudio](/scicomputing/software_R/#run-rstudio-server-on-an-hpc-machi
 
 #### With Jupyter
 
-To use environment modules with jupyter...
+We supply a `JupyterLab` module you can load along with whichever other modules you need. On the command line, load these additional Environment Modules at the same time as JupyterLab. For example, to load Seaborn with Jupyter:
+
+```
+ml purge
+
+ml JupyterLab/4.0.3-GCCcore-12.2.0 Seaborn/0.12.2-foss-2022b 
+jupyter lab --ip=0.0.0.0 --port=$(fhfreeport) --no-browser
+```
+
+See [Using Jupyter on rhino](/scicomputing/software_python/#using-jupyter-on-rhino) for the full instructions, or use [Open OnDemand](/scicomputing/access_openondemand/) for the easiest way to launch Jupyter Lab without loading modules yourself.
 
 ## Docker Containers
 

--- a/_scicomputing/compute_environments.md
+++ b/_scicomputing/compute_environments.md
@@ -94,7 +94,7 @@ The above line will load a different version of the software package over time a
 
 #### With WDL
 
-WDL and Nextflow commonly use [Docker](/compdemos/Docker/) contiainers to access required packages. You can also use our Environment Modules instead of Docker.
+WDL commonly uses [Docker](/compdemos/Docker/) contiainers to access required packages. You can use our Environment Modules instead of Docker.
 
 Instead of specifying a `docker` image in a task's `runtime` section, you can specify a `modules` attribute naming the Environment Module(s) to load:
 
@@ -104,7 +104,7 @@ runtime {
 }
 ```
 
-This requires an execution engine that has been configured to support Environment Modules. 
+This requires an execution engine that has been configured to support Environment Modules (e.g., Cromwell on our cluster). 
 
 See the [Environment Modules (HPC-specific)](/datascience/wdl_workflows/#environment-modules-hpc-specific) section of our [WDL Workflows](/datascience/wdl_workflows/) page for more detail.
 

--- a/_scicomputing/compute_environments.md
+++ b/_scicomputing/compute_environments.md
@@ -92,18 +92,21 @@ The above line will load a different version of the software package over time a
 
 > Note: This does mean that your script will only work in environments with the specific Environment Module version you are loading. That environment module may not be initially available on systems outside Fred Hutch or on internal systems follow upgrades. You can either request the specific version be added, or edit your script to load an available package version.
 
-#### With Workflow Managers
+#### With WDL
 
-If desired, one way to manage jobs, environments, and data transfers particularly in a series of linked tasks or jobs is to use a [workflow manager](/datascience/using_workflows/).  Workflow managers allow you to describe a workflow as a series of individual tasks.  Then the workflow manager software does the work of:
+WDL and Nextflow commonly use [Docker](/compdemos/Docker/) contiainers to access required packages. You can also use our Environment Modules instead of Docker.
 
-- sending the jobs to the compute resources
-- deciding what tasks can be done in parallel
-- staging data for use and keeping track of inputs and outputs
-- environment management (via [Docker](/compdemos/Docker/) containers or environment modules)
-- monitoring jobs and providing you with metadata about them and the workflow itself
+Instead of specifying a `docker` image in a task's `runtime` section, you can specify a `modules` attribute naming the Environment Module(s) to load:
 
-At Fred Hutch, [Nextflow](/compdemos/nextflow/) and [WDL workflows](/datascience/wdl_workflows/) are the primary workflow systems in use. WDL workflows can be executed using [multiple engines](/datademos/wdl_execution_engines/) including Cromwell, miniWDL, and Sprocket, while Nextflow has its own execution engine. Users are actively curating shared support and resources, with the [WILDS WDL Library](/datascience/wilds_wdl/) being a key resource for WDL workflows, and the [Fred Hutch NextFlow catalog](/datascience/nextflow_catalog/) being a key resource for Nextflow workflows. See the [Using Workflows](/datascience/using_workflows/) page for more information on workflow systems.
+```wdl
+runtime {
+  modules: "SAMtools/1.11-GCC-10.2.0"
+}
+```
 
+This requires an execution engine that has been configured to support Environment Modules. 
+
+See the [Environment Modules (HPC-specific)](/datascience/wdl_workflows/#environment-modules-hpc-specific) section of our [WDL Workflows](/datascience/wdl_workflows/) page for more detail.
 
 #### With VSCode
 

--- a/_scicomputing/compute_environments.md
+++ b/_scicomputing/compute_environments.md
@@ -104,6 +104,21 @@ If desired, one way to manage jobs, environments, and data transfers particularl
 
 At Fred Hutch, [Nextflow](/compdemos/nextflow/) and [WDL workflows](/datascience/wdl_workflows/) are the primary workflow systems in use. WDL workflows can be executed using [multiple engines](/datademos/wdl_execution_engines/) including Cromwell, miniWDL, and Sprocket, while Nextflow has its own execution engine. Users are actively curating shared support and resources, with the [WILDS WDL Library](/datascience/wilds_wdl/) being a key resource for WDL workflows, and the [Fred Hutch NextFlow catalog](/datascience/nextflow_catalog/) being a key resource for Nextflow workflows. See the [Using Workflows](/datascience/using_workflows/) page for more information on workflow systems.
 
+
+#### With VSCode
+
+We recommend creating a Python virtual environment that captures your currently loaded modules and reloads them automatically whenever the environment is activated. 
+
+This is becuase VSCode's Remote SSH extension can't load cluster Environment Modules when you connect to it. The remote session starts before your shell would normally load modules from `.bashrc` or `.profile`.
+
+See [Using Modules with VS Code](/compdemos/VS-Code_lmod/) for the workaround.
+
+#### With RStudio
+
+To use environment modules with rstudio...
+
+#### With Jupyter
+
 ## Docker Containers
 
 Docker containers package software and all dependencies into a standardized, reproducible computational environment. They enable scientists to run tools using the exact same configuration across different computing platforms, ensuring reproducible results. Docker containers isolate the computational environment without the overhead of full virtual machines.

--- a/_scicomputing/compute_environments.md
+++ b/_scicomputing/compute_environments.md
@@ -132,7 +132,7 @@ See [Using Jupyter on rhino](/scicomputing/software_python/#using-jupyter-on-rhi
 
 ## Docker Containers
 
-Docker containers package software and all dependencies into a standardized, reproducible computational environment. They are different from Environment Modules. Read more about Docke here: [Using Docker at Fred Hutch](/compdemos/Docker/).
+Docker containers package software and all dependencies into a standardized, reproducible computational environment. They are different from Environment Modules. Read more about Docker here: [Using Docker at Fred Hutch](/compdemos/Docker/).
 
 ## Installing Custom Software Packages
 If you do not find the software you need, a support package or library, or the specific version you need, you have two options:

--- a/_scicomputing/compute_environments.md
+++ b/_scicomputing/compute_environments.md
@@ -105,7 +105,7 @@ See the [Environment Modules (HPC-specific)](/datascience/wdl_workflows/#environ
 
 We recommend creating a Python virtual environment that captures your currently loaded modules and reloads them automatically whenever the environment is activated. 
 
-This is becuase VSCode's Remote SSH extension can't load cluster Environment Modules when you connect to it. The remote session starts before your shell would normally load modules from `.bashrc` or `.profile`.
+This is because VSCode's Remote SSH extension can't load cluster Environment Modules when you connect to it. The remote session starts before your shell would normally load modules from `.bashrc` or `.profile`.
 
 See [Using Modules with VS Code](/compdemos/VS-Code_lmod/) for the workaround.
 

--- a/_scicomputing/compute_environments.md
+++ b/_scicomputing/compute_environments.md
@@ -4,19 +4,12 @@ last_modified_at: 2025-11-11
 primary_reviewers: bmcgough
 ---
 
-The Fred Hutch provides researchers on campus access to high performance computing using on-premise resources.  The various technologies provided are outlined on our [Technologies](/scicomputing/compute_platforms/) page along with the basic information required for researchers to identify which FH resource might be best suited to their particular computing needs.
+Beyond what's available on local workstations, Scientific Computing maintains a large library of pre-compiled software packages on our HPC cluster and Linux systems. Reasons to use software maintained by SciComp include:
+- Packages are often faster due to compiler optimizations
+- Packages are reproducible in or outside Fred Hutch
+- Rapid access to many software packages and versions
 
-The Scientific Computing group supports additional software used in scientific research beyond those available on local workstations. A large number of pre-compiled packages are already available on our high performance computing (HPC) cluster and Linux systems. Individual user installation of packages and language modules is also supported.
-
-Reasons to use scientific software maintained by SciComp include:
-- packages are often faster due to compiler optimizations
-- packages are reproducible in or outside Fred Hutch
-- rapid access to many software packages and package versions
-
-
-## Environment Modules
-
-On the command line and in scripts, we use the Environment Module system to make software versions available in a modular and malleable way. Environment Modules provide modular access to one version of one or more software packages to help improve reproducibility. We use a system called EasyBuild to create modules for everyone to use - there are over a thousand modules already available. The implementation of Environment Modules we use is **Lmod**, and the commands you use to interact with Environment Modules are `module` or `ml`.  For more information on what modules we have available for use on `rhino` and `gizmo` see our [Scientific Software](/scicomputing/compute_scientificSoftware/) page.  This page details available modules of R, python and all other life sciences oriented software modules available.  
+We use **Lmod**, an Environment Module system built with EasyBuild, to make specific software versions available on the command line and in scripts - over a thousand modules are already available. Use the `module` or `ml` commands to interact with them. See [Scientific Software](/scicomputing/compute_scientificSoftware/) for the R, Python, and other modules available on `rhino` and `gizmo`.
 
 
 ### How to Use Environment Modules

--- a/_scicomputing/compute_environments.md
+++ b/_scicomputing/compute_environments.md
@@ -115,9 +115,15 @@ See [Using Modules with VS Code](/compdemos/VS-Code_lmod/) for the workaround.
 
 #### With RStudio
 
-To use environment modules with rstudio...
+The easiest way to use Environment Modules with RStudio is through [Open OnDemand](/scicomputing/access_openondemand/), which launches RStudio Server for you and lets you pick which modules to use when starting a session.
+
+Be sure to use the [Fred Hutch RStudio Server](https://openondemand.fredhutch.org/pun/sys/dashboard/batch_connect/sys/ood_rstudio_server/session_contexts/new), which uses the modules on the cluster, not [RStudio Server/Apptainer](https://openondemand.fredhutch.org/pun/sys/dashboard/batch_connect/sys/ood_rstudio_server_apptainer/session_contexts/new).
+
+See [R and RStudio](/scicomputing/software_R/#run-rstudio-server-on-an-hpc-machine) for more on both options.
 
 #### With Jupyter
+
+To use environment modules with jupyter...
 
 ## Docker Containers
 

--- a/_scicomputing/compute_environments.md
+++ b/_scicomputing/compute_environments.md
@@ -136,34 +136,7 @@ See [Using Jupyter on rhino](/scicomputing/software_python/#using-jupyter-on-rhi
 
 ## Docker Containers
 
-Docker containers package software and all dependencies into a standardized, reproducible computational environment. They enable scientists to run tools using the exact same configuration across different computing platforms, ensuring reproducible results. Docker containers isolate the computational environment without the overhead of full virtual machines.
-
-For a comprehensive introduction to Docker at Fred Hutch, see [Using Docker at Fred Hutch](/compdemos/Docker/), which covers:
-
-- [What Docker is and how it works](/compdemos/Docker/#what-is-docker)
-- [Using pre-built containers from WILDS and other sources](/compdemos/Docker/#using-existing-docker-images)
-- [Running Docker on your local computer](/compdemos/Docker/#running-docker-on-your-local-computer)
-- [Using Docker containers on the Fred Hutch cluster (via Apptainer)](/compdemos/Docker/#using-docker-on-the-cluster)
-- [Creating your own Docker images](/compdemos/Docker/#creating-your-own-docker-images)
-- [Using Docker in WDL and other workflow systems](/compdemos/Docker/#using-docker-with-workflows)
-
-**Important:** Docker requires root access and cannot run directly on shared compute environments like `Rhino` or `Gizmo`. Instead, use [Apptainer](/compdemos/Apptainer/) to run Docker containers on the cluster. Apptainer can pull and run Docker images directly from Docker Hub without requiring administrator privileges. See the [Apptainer documentation](/compdemos/Apptainer/) for details.
-
-Cloud computing platforms like [AWS Batch](/scicomputing/compute_cloud/) are built on Docker, using containers to ensure consistent execution environments across distributed computing resources.
-
-### Docker Resources
-
-#### Fred Hutch Resources
-
-  * **WILDS Docker Library ([GitHub](https://github.com/getwilds/wilds-docker-library), [DockerHub](https://hub.docker.com/u/getwilds))** - Tested, versioned Docker containers for bioinformatics tools, built and maintained by the WILDS team at Fred Hutch. These containers are designed to work seamlessly with WDL workflows and other workflow systems.
-  * **[Fred Hutch DockerHub](https://hub.docker.com/u/fredhutch)** - Additional containers available for Fred Hutch researchers.
-
-#### Community Resources
-
-  * **[Docker Hub](https://hub.docker.com/)** - The most commonly used server to share Docker images.
-  * **[Quay](https://quay.io/)** - Another commonly used server to share Docker images.
-  * **[BioContainers](https://biocontainers.pro/)** - A free and open source project to collect a set of images that contain useful bioinformatics tools.
-
+Docker containers package software and all dependencies into a standardized, reproducible computational environment. They are different from Environment Modules. Read more about Docke here: [Using Docker at Fred Hutch](/compdemos/Docker/).
 
 ## Installing Custom Software Packages
 If you do not find the software you need, a support package or library, or the specific version you need, you have two options:


### PR DESCRIPTION
This PR updates the central Environment Modules page to specifically summarize and link out to sciwki descriptions of how to use environment modules with:
- WDL (note, I don't think we can use our modules with Nextflow)
- VSCode
- Rstudio
- Jupyter

It also makes the introductory paragraphs more concise and more focused on the modules and not the cluster in general.

Fixes #1288 

Note: I think this PR would render PR #1311 obsolete and so that could be closed if this is merged.